### PR TITLE
Quality of life, bug fixes and sort rewrite

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
 # Authors
 Ordered by the date of the first commit.
 
-* Zoe Roux ([@AnonymusRaccoon](http://github.com/AnonymusRaccoon))
+* Zoe Roux ([@zoriya](http://github.com/zoriya))

--- a/back/.editorconfig
+++ b/back/.editorconfig
@@ -16,6 +16,7 @@ dotnet_diagnostic.IDE0058.severity = none
 dotnet_diagnostic.IDE0046.severity = none
 dotnet_diagnostic.CA1848.severity = none
 dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.CA1716.severity = none
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 csharp_using_directive_placement = outside_namespace:warning

--- a/back/src/Kyoo.Abstractions/Controllers/ILibraryManager.cs
+++ b/back/src/Kyoo.Abstractions/Controllers/ILibraryManager.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Kyoo.Abstractions.Models;
@@ -256,7 +255,7 @@ namespace Kyoo.Abstractions.Controllers
 		/// <typeparam name="T">The type of the source object</typeparam>
 		/// <typeparam name="T2">The related resource's type</typeparam>
 		/// <returns>The param <paramref name="obj"/></returns>
-		/// <seealso cref="Load{T,T2}(T, System.Linq.Expressions.Expression{System.Func{T,System.Collections.Generic.ICollection{T2}}}, bool)"/>
+		/// <seealso cref="Load{T,T2}(T, Expression{Func{T,ICollection{T2}}}, bool)"/>
 		/// <seealso cref="Load{T}(T, string, bool)"/>
 		/// <seealso cref="Load(IResource, string, bool)"/>
 		Task<T> Load<T, T2>([NotNull] T obj, Expression<Func<T, T2>> member, bool force = false)
@@ -274,7 +273,7 @@ namespace Kyoo.Abstractions.Controllers
 		/// <typeparam name="T">The type of the source object</typeparam>
 		/// <typeparam name="T2">The related resource's type</typeparam>
 		/// <returns>The param <paramref name="obj"/></returns>
-		/// <seealso cref="Load{T,T2}(T, System.Linq.Expressions.Expression{System.Func{T,T2}}, bool)"/>
+		/// <seealso cref="Load{T,T2}(T, Expression{Func{T,T2}}, bool)"/>
 		/// <seealso cref="Load{T}(T, string, bool)"/>
 		/// <seealso cref="Load(IResource, string, bool)"/>
 		Task<T> Load<T, T2>([NotNull] T obj, Expression<Func<T, ICollection<T2>>> member, bool force = false)
@@ -291,8 +290,8 @@ namespace Kyoo.Abstractions.Controllers
 		/// </param>
 		/// <typeparam name="T">The type of the source object</typeparam>
 		/// <returns>The param <paramref name="obj"/></returns>
-		/// <seealso cref="Load{T,T2}(T, System.Linq.Expressions.Expression{System.Func{T,T2}}, bool)"/>
-		/// <seealso cref="Load{T,T2}(T, System.Linq.Expressions.Expression{System.Func{T,System.Collections.Generic.ICollection{T2}}}, bool)"/>
+		/// <seealso cref="Load{T,T2}(T, Expression{Func{T,T2}}, bool)"/>
+		/// <seealso cref="Load{T,T2}(T, Expression{Func{T,ICollection{T2}}}, bool)"/>
 		/// <seealso cref="Load(IResource, string, bool)"/>
 		Task<T> Load<T>([NotNull] T obj, string memberName, bool force = false)
 			where T : class, IResource;
@@ -305,8 +304,8 @@ namespace Kyoo.Abstractions.Controllers
 		/// <param name="force">
 		/// <c>true</c> if you want to load the relation even if it is not null, <c>false</c> otherwise.
 		/// </param>
-		/// <seealso cref="Load{T,T2}(T, System.Linq.Expressions.Expression{System.Func{T,T2}}, bool)"/>
-		/// <seealso cref="Load{T,T2}(T, System.Linq.Expressions.Expression{System.Func{T,System.Collections.Generic.ICollection{T2}}}, bool)"/>
+		/// <seealso cref="Load{T,T2}(T, Expression{Func{T,T2}}, bool)"/>
+		/// <seealso cref="Load{T,T2}(T, Expression{Func{T,ICollection{T2}}}, bool)"/>
 		/// <seealso cref="Load{T}(T, string, bool)"/>
 		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 		Task Load([NotNull] IResource obj, string memberName, bool force = false);
@@ -328,21 +327,6 @@ namespace Kyoo.Abstractions.Controllers
 		/// <summary>
 		/// Get items (A wrapper around shows or collections) from a library.
 		/// </summary>
-		/// <param name="id">The ID of the library</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No library exist with the given ID.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<LibraryItem>> GetItemsFromLibrary(int id,
-			[Optional] Expression<Func<LibraryItem, bool>> where,
-			Expression<Func<LibraryItem, object>> sort,
-			Pagination limit = default
-		) => GetItemsFromLibrary(id, where, new Sort<LibraryItem>(sort), limit);
-
-		/// <summary>
-		/// Get items (A wrapper around shows or collections) from a library.
-		/// </summary>
 		/// <param name="slug">The slug of the library</param>
 		/// <param name="where">A filter function</param>
 		/// <param name="sort">Sort information (sort order and sort by)</param>
@@ -355,21 +339,6 @@ namespace Kyoo.Abstractions.Controllers
 			Pagination limit = default);
 
 		/// <summary>
-		/// Get items (A wrapper around shows or collections) from a library.
-		/// </summary>
-		/// <param name="slug">The slug of the library</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No library exist with the given slug.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<LibraryItem>> GetItemsFromLibrary(string slug,
-			[Optional] Expression<Func<LibraryItem, bool>> where,
-			Expression<Func<LibraryItem, object>> sort,
-			Pagination limit = default
-		) => GetItemsFromLibrary(slug, where, new Sort<LibraryItem>(sort), limit);
-
-		/// <summary>
 		/// Get people's roles from a show.
 		/// </summary>
 		/// <param name="showID">The ID of the show</param>
@@ -386,21 +355,6 @@ namespace Kyoo.Abstractions.Controllers
 		/// <summary>
 		/// Get people's roles from a show.
 		/// </summary>
-		/// <param name="showID">The ID of the show</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="Show"/> exist with the given ID.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetPeopleFromShow(int showID,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetPeopleFromShow(showID, where, new Sort<PeopleRole>(sort), limit);
-
-		/// <summary>
-		/// Get people's roles from a show.
-		/// </summary>
 		/// <param name="showSlug">The slug of the show</param>
 		/// <param name="where">A filter function</param>
 		/// <param name="sort">Sort information (sort order and sort by)</param>
@@ -411,21 +365,6 @@ namespace Kyoo.Abstractions.Controllers
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default);
-
-		/// <summary>
-		/// Get people's roles from a show.
-		/// </summary>
-		/// <param name="showSlug">The slug of the show</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="Show"/> exist with the given slug.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetPeopleFromShow(string showSlug,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetPeopleFromShow(showSlug, where, new Sort<PeopleRole>(sort), limit);
 
 		/// <summary>
 		/// Get people's roles from a person.
@@ -444,21 +383,6 @@ namespace Kyoo.Abstractions.Controllers
 		/// <summary>
 		/// Get people's roles from a person.
 		/// </summary>
-		/// <param name="id">The id of the person</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="People"/> exist with the given ID.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetRolesFromPeople(int id,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetRolesFromPeople(id, where, new Sort<PeopleRole>(sort), limit);
-
-		/// <summary>
-		/// Get people's roles from a person.
-		/// </summary>
 		/// <param name="slug">The slug of the person</param>
 		/// <param name="where">A filter function</param>
 		/// <param name="sort">Sort information (sort order and sort by)</param>
@@ -469,21 +393,6 @@ namespace Kyoo.Abstractions.Controllers
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default);
-
-		/// <summary>
-		/// Get people's roles from a person.
-		/// </summary>
-		/// <param name="slug">The slug of the person</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="People"/> exist with the given slug.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetRolesFromPeople(string slug,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetRolesFromPeople(slug, where, new Sort<PeopleRole>(sort), limit);
 
 		/// <summary>
 		/// Setup relations between a show, a library and a collection
@@ -515,22 +424,6 @@ namespace Kyoo.Abstractions.Controllers
 			Sort<T> sort = default,
 			Pagination limit = default)
 			where T : class, IResource;
-
-		/// <summary>
-		/// Get all resources with filters
-		/// </summary>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by function</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <typeparam name="T">The type of resources to load</typeparam>
-		/// <returns>A list of resources that match every filters</returns>
-		Task<ICollection<T>> GetAll<T>([Optional] Expression<Func<T, bool>> where,
-			Expression<Func<T, object>> sort,
-			Pagination limit = default)
-			where T : class, IResource
-		{
-			return GetAll(where, new Sort<T>(sort), limit);
-		}
 
 		/// <summary>
 		/// Get the count of resources that match the filter

--- a/back/src/Kyoo.Abstractions/Controllers/IRepository.cs
+++ b/back/src/Kyoo.Abstractions/Controllers/IRepository.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Kyoo.Abstractions.Models;
@@ -105,19 +104,6 @@ namespace Kyoo.Abstractions.Controllers
 		Task<ICollection<T>> GetAll(Expression<Func<T, bool>> where = null,
 			Sort<T> sort = default,
 			Pagination limit = default);
-
-		/// <summary>
-		/// Get every resources that match all filters
-		/// </summary>
-		/// <param name="where">A filter predicate</param>
-		/// <param name="sort">A sort by predicate. The order is ascending.</param>
-		/// <param name="limit">How pagination should be done (where to start and how many to return)</param>
-		/// <returns>A list of resources that match every filters</returns>
-		[ItemNotNull]
-		Task<ICollection<T>> GetAll([Optional] Expression<Func<T, bool>> where,
-			Expression<Func<T, object>> sort,
-			Pagination limit = default
-		) => GetAll(where, new Sort<T>(sort), limit);
 
 		/// <summary>
 		/// Get the number of resources that match the filter's predicate.
@@ -355,21 +341,6 @@ namespace Kyoo.Abstractions.Controllers
 		/// <summary>
 		/// Get items (A wrapper around shows or collections) from a library.
 		/// </summary>
-		/// <param name="id">The ID of the library</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No library exist with the given ID.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		public Task<ICollection<LibraryItem>> GetFromLibrary(int id,
-			[Optional] Expression<Func<LibraryItem, bool>> where,
-			Expression<Func<LibraryItem, object>> sort,
-			Pagination limit = default
-		) => GetFromLibrary(id, where, new Sort<LibraryItem>(sort), limit);
-
-		/// <summary>
-		/// Get items (A wrapper around shows or collections) from a library.
-		/// </summary>
 		/// <param name="slug">The slug of the library</param>
 		/// <param name="where">A filter function</param>
 		/// <param name="sort">Sort information (sort order and sort by)</param>
@@ -380,21 +351,6 @@ namespace Kyoo.Abstractions.Controllers
 			Expression<Func<LibraryItem, bool>> where = null,
 			Sort<LibraryItem> sort = default,
 			Pagination limit = default);
-
-		/// <summary>
-		/// Get items (A wrapper around shows or collections) from a library.
-		/// </summary>
-		/// <param name="slug">The slug of the library</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No library exist with the given slug.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		public Task<ICollection<LibraryItem>> GetFromLibrary(string slug,
-			[Optional] Expression<Func<LibraryItem, bool>> where,
-			Expression<Func<LibraryItem, object>> sort,
-			Pagination limit = default
-		) => GetFromLibrary(slug, where, new Sort<LibraryItem>(sort), limit);
 	}
 
 	/// <summary>
@@ -434,21 +390,6 @@ namespace Kyoo.Abstractions.Controllers
 		/// <summary>
 		/// Get people's roles from a show.
 		/// </summary>
-		/// <param name="showID">The ID of the show</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="Show"/> exist with the given ID.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetFromShow(int showID,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetFromShow(showID, where, new Sort<PeopleRole>(sort), limit);
-
-		/// <summary>
-		/// Get people's roles from a show.
-		/// </summary>
 		/// <param name="showSlug">The slug of the show</param>
 		/// <param name="where">A filter function</param>
 		/// <param name="sort">Sort information (sort order and sort by)</param>
@@ -459,21 +400,6 @@ namespace Kyoo.Abstractions.Controllers
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default);
-
-		/// <summary>
-		/// Get people's roles from a show.
-		/// </summary>
-		/// <param name="showSlug">The slug of the show</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="Show"/> exist with the given slug.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetFromShow(string showSlug,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetFromShow(showSlug, where, new Sort<PeopleRole>(sort), limit);
 
 		/// <summary>
 		/// Get people's roles from a person.
@@ -492,21 +418,6 @@ namespace Kyoo.Abstractions.Controllers
 		/// <summary>
 		/// Get people's roles from a person.
 		/// </summary>
-		/// <param name="id">The id of the person</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="People"/> exist with the given ID.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetFromPeople(int id,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetFromPeople(id, where, new Sort<PeopleRole>(sort), limit);
-
-		/// <summary>
-		/// Get people's roles from a person.
-		/// </summary>
 		/// <param name="slug">The slug of the person</param>
 		/// <param name="where">A filter function</param>
 		/// <param name="sort">Sort information (sort order and sort by)</param>
@@ -517,21 +428,6 @@ namespace Kyoo.Abstractions.Controllers
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default);
-
-		/// <summary>
-		/// Get people's roles from a person.
-		/// </summary>
-		/// <param name="slug">The slug of the person</param>
-		/// <param name="where">A filter function</param>
-		/// <param name="sort">A sort by method</param>
-		/// <param name="limit">How many items to return and where to start</param>
-		/// <exception cref="ItemNotFoundException">No <see cref="People"/> exist with the given slug.</exception>
-		/// <returns>A list of items that match every filters</returns>
-		Task<ICollection<PeopleRole>> GetFromPeople(string slug,
-			[Optional] Expression<Func<PeopleRole, bool>> where,
-			Expression<Func<PeopleRole, object>> sort,
-			Pagination limit = default
-		) => GetFromPeople(slug, where, new Sort<PeopleRole>(sort), limit);
 	}
 
 	/// <summary>
@@ -551,21 +447,6 @@ namespace Kyoo.Abstractions.Controllers
 			Sort<MetadataID> sort = default,
 			Pagination limit = default)
 			where T : class, IMetadata;
-
-		/// <summary>
-		/// Get a list of external ids that match all filters
-		/// </summary>
-		/// <param name="where">A predicate to add arbitrary filter</param>
-		/// <param name="sort">A sort by expression</param>
-		/// <param name="limit">Pagination information (where to start and how many to get)</param>
-		/// <typeparam name="T">The type of metadata to retrieve</typeparam>
-		/// <returns>A filtered list of external ids.</returns>
-		Task<ICollection<MetadataID>> GetMetadataID<T>([Optional] Expression<Func<MetadataID, bool>> where,
-			Expression<Func<MetadataID, object>> sort,
-			Pagination limit = default
-		)
-		where T : class, IMetadata
-			=> GetMetadataID<T>(where, new Sort<MetadataID>(sort), limit);
 	}
 
 	/// <summary>

--- a/back/src/Kyoo.Abstractions/Models/Exceptions/DuplicatedItemException.cs
+++ b/back/src/Kyoo.Abstractions/Models/Exceptions/DuplicatedItemException.cs
@@ -28,19 +28,19 @@ namespace Kyoo.Abstractions.Models.Exceptions
 	public class DuplicatedItemException : Exception
 	{
 		/// <summary>
-		/// Create a new <see cref="DuplicatedItemException"/> with the default message.
+		/// The existing object.
 		/// </summary>
-		public DuplicatedItemException()
-			: base("Already exists in the database.")
-		{ }
+		public object Existing { get; }
 
 		/// <summary>
-		/// Create a new <see cref="DuplicatedItemException"/> with a custom message.
+		/// Create a new <see cref="DuplicatedItemException"/> with the default message.
 		/// </summary>
-		/// <param name="message">The message to use</param>
-		public DuplicatedItemException(string message)
-			: base(message)
-		{ }
+		/// <param name="existing">The existing object.</param>
+		public DuplicatedItemException(object existing = null)
+			: base("Already exists in the database.")
+		{
+			Existing = existing;
+		}
 
 		/// <summary>
 		/// The serialization constructor.

--- a/back/src/Kyoo.Abstractions/Models/Page.cs
+++ b/back/src/Kyoo.Abstractions/Models/Page.cs
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kyoo.Utils;
@@ -41,6 +40,11 @@ namespace Kyoo.Abstractions.Models
 		public string First { get; }
 
 		/// <summary>
+		/// The link of the previous page.
+		/// </summary>
+		public string Previous { get; }
+
+		/// <summary>
 		/// The link of the next page.
 		/// </summary>
 		public string Next { get; }
@@ -60,12 +64,14 @@ namespace Kyoo.Abstractions.Models
 		/// </summary>
 		/// <param name="items">The list of items in the page.</param>
 		/// <param name="this">The link of the current page.</param>
+		/// <param name="previous">The link of the previous page.</param>
 		/// <param name="next">The link of the next page.</param>
 		/// <param name="first">The link of the first page.</param>
-		public Page(ICollection<T> items, string @this, string next, string first)
+		public Page(ICollection<T> items, string @this, string previous, string next, string first)
 		{
 			Items = items;
 			This = @this;
+			Previous = previous;
 			Next = next;
 			First = first;
 		}
@@ -85,6 +91,13 @@ namespace Kyoo.Abstractions.Models
 			Items = items;
 			This = url + query.ToQueryString();
 
+			if (items.Count > 0 && query.ContainsKey("afterID"))
+			{
+				query["afterID"] = items.First().ID.ToString();
+				query["reverse"] = "true";
+				Previous = url + query.ToQueryString();
+			}
+			query.Remove("reverse");
 			if (items.Count == limit && limit > 0)
 			{
 				query["afterID"] = items.Last().ID.ToString();

--- a/back/src/Kyoo.Abstractions/Models/Utils/Identifier.cs
+++ b/back/src/Kyoo.Abstractions/Models/Utils/Identifier.cs
@@ -113,7 +113,7 @@ namespace Kyoo.Abstractions.Models.Utils
 
 		/// <summary>
 		/// A matcher overload for nullable IDs. See
-		/// <see cref="Matcher{T}(System.Linq.Expressions.Expression{System.Func{T,int}},System.Linq.Expressions.Expression{System.Func{T,string}})"/>
+		/// <see cref="Matcher{T}(Expression{Func{T,int}},Expression{Func{T,string}})"/>
 		/// for more details.
 		/// </summary>
 		/// <param name="idGetter">An expression to retrieve an ID from the type <typeparamref name="T"/>.</param>

--- a/back/src/Kyoo.Abstractions/Models/Utils/Pagination.cs
+++ b/back/src/Kyoo.Abstractions/Models/Utils/Pagination.cs
@@ -21,32 +21,42 @@ namespace Kyoo.Abstractions.Controllers
 	/// <summary>
 	/// Information about the pagination. How many items should be displayed and where to start.
 	/// </summary>
-	public readonly struct Pagination
+	public class Pagination
 	{
 		/// <summary>
 		/// The count of items to return.
 		/// </summary>
-		public int Count { get; }
+		public int Limit { get; set; }
 
 		/// <summary>
 		/// Where to start? Using the given sort.
 		/// </summary>
-		public int? AfterID { get; }
+		public int? AfterID { get; set; }
 
 		/// <summary>
 		/// Should the previous page be returned instead of the next?
 		/// </summary>
-		public bool Reverse { get; }
+		public bool Reverse { get; set; }
+
+		/// <summary>
+		/// Create a new <see cref="Pagination"/> with default values.
+		/// </summary>
+		public Pagination()
+		{
+			Limit = 20;
+			AfterID = null;
+			Reverse = false;
+		}
 
 		/// <summary>
 		/// Create a new <see cref="Pagination"/> instance.
 		/// </summary>
-		/// <param name="count">Set the <see cref="Count"/> value</param>
+		/// <param name="count">Set the <see cref="Limit"/> value</param>
 		/// <param name="afterID">Set the <see cref="AfterID"/> value. If not specified, it will start from the start</param>
 		/// <param name="reverse">Should the previous page be returned instead of the next?</param>
 		public Pagination(int count, int? afterID = null, bool reverse = false)
 		{
-			Count = count;
+			Limit = count;
 			AfterID = afterID;
 			Reverse = reverse;
 		}
@@ -54,7 +64,7 @@ namespace Kyoo.Abstractions.Controllers
 		/// <summary>
 		/// Implicitly create a new pagination from a limit number.
 		/// </summary>
-		/// <param name="limit">Set the <see cref="Count"/> value</param>
+		/// <param name="limit">Set the <see cref="Limit"/> value</param>
 		/// <returns>A new <see cref="Pagination"/> instance</returns>
 		public static implicit operator Pagination(int limit) => new(limit);
 	}

--- a/back/src/Kyoo.Abstractions/Models/Utils/Pagination.cs
+++ b/back/src/Kyoo.Abstractions/Models/Utils/Pagination.cs
@@ -34,14 +34,21 @@ namespace Kyoo.Abstractions.Controllers
 		public int? AfterID { get; }
 
 		/// <summary>
+		/// Should the previous page be returned instead of the next?
+		/// </summary>
+		public bool Reverse { get; }
+
+		/// <summary>
 		/// Create a new <see cref="Pagination"/> instance.
 		/// </summary>
 		/// <param name="count">Set the <see cref="Count"/> value</param>
 		/// <param name="afterID">Set the <see cref="AfterID"/> value. If not specified, it will start from the start</param>
-		public Pagination(int count, int? afterID = null)
+		/// <param name="reverse">Should the previous page be returned instead of the next?</param>
+		public Pagination(int count, int? afterID = null, bool reverse = false)
 		{
 			Count = count;
 			AfterID = afterID;
+			Reverse = reverse;
 		}
 
 		/// <summary>

--- a/back/src/Kyoo.Abstractions/Models/WatchItem.cs
+++ b/back/src/Kyoo.Abstractions/Models/WatchItem.cs
@@ -184,10 +184,16 @@ namespace Kyoo.Abstractions.Models
 				Fonts = await transcoder.ListFonts(ep),
 				PreviousEpisode = ep.Show.IsMovie
 					? null
-					: (await library.GetAll<Episode>(limit: new Pagination(1, ep.ID, true))).FirstOrDefault(),
+					: (await library.GetAll<Episode>(
+							where: x => x.ShowID == ep.ShowID,
+							limit: new Pagination(1, ep.ID, true)
+						)).FirstOrDefault(),
 				NextEpisode = ep.Show.IsMovie
 					? null
-					: (await library.GetAll<Episode>(limit: new Pagination(1, ep.ID))).FirstOrDefault(),
+					: (await library.GetAll<Episode>(
+							where: x => x.ShowID == ep.ShowID,
+							limit: new Pagination(1, ep.ID)
+						)).FirstOrDefault(),
 				Chapters = await _GetChapters(ep, fs),
 				IsMovie = ep.Show.IsMovie
 			};

--- a/back/src/Kyoo.Abstractions/Models/WatchItem.cs
+++ b/back/src/Kyoo.Abstractions/Models/WatchItem.cs
@@ -163,47 +163,6 @@ namespace Kyoo.Abstractions.Models
 			await library.Load(ep, x => x.Show);
 			await library.Load(ep, x => x.Tracks);
 
-			// if (!ep.Show.IsMovie)
-			// {
-			// 	if (ep.AbsoluteNumber != null)
-			// 	{
-			// 		previous = await library.GetOrDefault(
-			// 			x => x.ShowID == ep.ShowID && x.AbsoluteNumber < ep.AbsoluteNumber,
-			// 			new Sort<Episode>(x => x.AbsoluteNumber, true)
-			// 		);
-			// 		next = await library.GetOrDefault(
-			// 			x => x.ShowID == ep.ShowID && x.AbsoluteNumber > ep.AbsoluteNumber,
-			// 			new Sort<Episode>(x => x.AbsoluteNumber)
-			// 		);
-			// 	}
-			// 	else if (ep.SeasonNumber != null && ep.EpisodeNumber != null)
-			// 	{
-			// 		previous = await library.GetOrDefault(
-			// 			x => x.ShowID == ep.ShowID
-			// 				&& x.SeasonNumber == ep.SeasonNumber
-			// 				&& x.EpisodeNumber < ep.EpisodeNumber,
-			// 			new Sort<Episode>(x => x.EpisodeNumber, true)
-			// 		);
-			// 		previous ??= await library.GetOrDefault(
-			// 			x => x.ShowID == ep.ShowID
-			// 				&& x.SeasonNumber == ep.SeasonNumber - 1,
-			// 			new Sort<Episode>(x => x.EpisodeNumber, true)
-			// 		);
-			//
-			// 		next = await library.GetOrDefault(
-			// 			x => x.ShowID == ep.ShowID
-			// 				&& x.SeasonNumber == ep.SeasonNumber
-			// 				&& x.EpisodeNumber > ep.EpisodeNumber,
-			// 			new Sort<Episode>(x => x.EpisodeNumber)
-			// 		);
-			// 		next ??= await library.GetOrDefault(
-			// 			x => x.ShowID == ep.ShowID
-			// 				&& x.SeasonNumber == ep.SeasonNumber + 1,
-			// 			new Sort<Episode>(x => x.EpisodeNumber)
-			// 		);
-			// 	}
-			// }
-
 			return new WatchItem
 			{
 				EpisodeID = ep.ID,

--- a/back/src/Kyoo.Core/Controllers/RegexIdentifier.cs
+++ b/back/src/Kyoo.Core/Controllers/RegexIdentifier.cs
@@ -68,8 +68,7 @@ namespace Kyoo.Core.Controllers
 			string libraryPath = (await _libraryManager.GetAll<Library>())
 				.SelectMany(x => x.Paths)
 				.Where(path.StartsWith)
-				.OrderByDescending(x => x.Length)
-				.FirstOrDefault();
+				.MaxBy(x => x.Length);
 			return path[(libraryPath?.Length ?? 0)..];
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/CollectionRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/CollectionRepository.cs
@@ -72,7 +72,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated collection (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/CollectionRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/CollectionRepository.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Kyoo.Abstractions.Controllers;
 using Kyoo.Abstractions.Models;
@@ -44,7 +43,7 @@ namespace Kyoo.Core.Controllers
 		private readonly IProviderRepository _providers;
 
 		/// <inheritdoc />
-		protected override Expression<Func<Collection, object>> DefaultSort => x => x.Name;
+		protected override Sort<Collection> DefaultSort => new Sort<Collection>.By(nameof(Collection.Name));
 
 		/// <summary>
 		/// Create a new <see cref="CollectionRepository"/>.
@@ -61,11 +60,11 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public override async Task<ICollection<Collection>> Search(string query)
 		{
-			return await _database.Collections
-				.Where(_database.Like<Collection>(x => x.Name + " " + x.Slug, $"%{query}%"))
-				.OrderBy(DefaultSort)
-				.Take(20)
-				.ToListAsync();
+			return await Sort(
+				_database.Collections
+					.Where(_database.Like<Collection>(x => x.Name + " " + x.Slug, $"%{query}%"))
+					.Take(20)
+				).ToListAsync();
 		}
 
 		/// <inheritdoc />

--- a/back/src/Kyoo.Core/Controllers/Repositories/EpisodeRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/EpisodeRepository.cs
@@ -142,7 +142,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated episode (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return await _ValidateTracks(obj);
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/GenreRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/GenreRepository.cs
@@ -67,7 +67,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated genre (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/GenreRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/GenreRepository.cs
@@ -39,7 +39,7 @@ namespace Kyoo.Core.Controllers
 		private readonly DatabaseContext _database;
 
 		/// <inheritdoc />
-		protected override Expression<Func<Genre, object>> DefaultSort => x => x.Slug;
+		protected override Sort<Genre> DefaultSort => new Sort<Genre>.By(x => x.Slug);
 
 		/// <summary>
 		/// Create a new <see cref="GenreRepository"/>.
@@ -54,9 +54,10 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public override async Task<ICollection<Genre>> Search(string query)
 		{
-			return await _database.Genres
-				.Where(_database.Like<Genre>(x => x.Name, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.Genres
+					.Where(_database.Like<Genre>(x => x.Name, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}

--- a/back/src/Kyoo.Core/Controllers/Repositories/LibraryItemRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/LibraryItemRepository.cs
@@ -147,10 +147,12 @@ namespace Kyoo.Core.Controllers
 			Sort<LibraryItem> sort = default,
 			Pagination limit = default)
 		{
-			ICollection<LibraryItem> items = await ApplyFilters(_LibraryRelatedQuery(x => x.ID == id),
+			ICollection<LibraryItem> items = await ApplyFilters(
+				_LibraryRelatedQuery(x => x.ID == id),
 				where,
 				sort,
-				limit);
+				limit
+			);
 			if (!items.Any() && await _libraries.Value.GetOrDefault(id) == null)
 				throw new ItemNotFoundException();
 			return items;
@@ -162,10 +164,12 @@ namespace Kyoo.Core.Controllers
 			Sort<LibraryItem> sort = default,
 			Pagination limit = default)
 		{
-			ICollection<LibraryItem> items = await ApplyFilters(_LibraryRelatedQuery(x => x.Slug == slug),
+			ICollection<LibraryItem> items = await ApplyFilters(
+				_LibraryRelatedQuery(x => x.Slug == slug),
 				where,
 				sort,
-				limit);
+				limit
+			);
 			if (!items.Any() && await _libraries.Value.GetOrDefault(slug) == null)
 				throw new ItemNotFoundException();
 			return items;

--- a/back/src/Kyoo.Core/Controllers/Repositories/LibraryItemRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/LibraryItemRepository.cs
@@ -45,7 +45,7 @@ namespace Kyoo.Core.Controllers
 		private readonly Lazy<ILibraryRepository> _libraries;
 
 		/// <inheritdoc />
-		protected override Expression<Func<LibraryItem, object>> DefaultSort => x => x.Title;
+		protected override Sort<LibraryItem> DefaultSort => new Sort<LibraryItem>.By(x => x.Title);
 
 		/// <summary>
 		/// Create a new <see cref="LibraryItemRepository"/>.
@@ -92,9 +92,10 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public override async Task<ICollection<LibraryItem>> Search(string query)
 		{
-			return await _database.LibraryItems
-				.Where(_database.Like<LibraryItem>(x => x.Title, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.LibraryItems
+					.Where(_database.Like<LibraryItem>(x => x.Title, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}

--- a/back/src/Kyoo.Core/Controllers/Repositories/LibraryRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/LibraryRepository.cs
@@ -75,7 +75,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated library (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/LibraryRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/LibraryRepository.cs
@@ -45,7 +45,7 @@ namespace Kyoo.Core.Controllers
 		private readonly IProviderRepository _providers;
 
 		/// <inheritdoc />
-		protected override Expression<Func<Library, object>> DefaultSort => x => x.ID;
+		protected override Sort<Library> DefaultSort => new Sort<Library>.By(x => x.ID);
 
 		/// <summary>
 		/// Create a new <see cref="LibraryRepository"/> instance.
@@ -62,9 +62,10 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public override async Task<ICollection<Library>> Search(string query)
 		{
-			return await _database.Libraries
-				.Where(_database.Like<Library>(x => x.Name + " " + x.Slug, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.Libraries
+					.Where(_database.Like<Library>(x => x.Name + " " + x.Slug, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}

--- a/back/src/Kyoo.Core/Controllers/Repositories/LocalRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/LocalRepository.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Kyoo.Abstractions.Controllers;
 using Kyoo.Abstractions.Models;
@@ -47,7 +48,7 @@ namespace Kyoo.Core.Controllers
 		/// <summary>
 		/// The default sort order that will be used for this resource's type.
 		/// </summary>
-		protected abstract Expression<Func<T, object>> DefaultSort { get; }
+		protected abstract Sort<T> DefaultSort { get; }
 
 		/// <summary>
 		/// Create a new base <see cref="LocalRepository{T}"/> with the given database handle.
@@ -60,6 +61,206 @@ namespace Kyoo.Core.Controllers
 
 		/// <inheritdoc/>
 		public Type RepositoryType => typeof(T);
+
+		/// <summary>
+		/// Sort the given query.
+		/// </summary>
+		/// <param name="query">The query to sort.</param>
+		/// <param name="sortBy">How to sort the query</param>
+		/// <returns>The newly sorted query.</returns>
+		protected IOrderedQueryable<T> Sort(IQueryable<T> query, Sort<T> sortBy = null)
+		{
+			sortBy ??= DefaultSort;
+
+			switch (sortBy)
+			{
+				case Sort<T>.Default:
+					return Sort(query, DefaultSort);
+				case Sort<T>.By(var key, var desc):
+					return desc
+						? query.OrderByDescending(x => EF.Property<object>(x, key))
+						: query.OrderBy(x => EF.Property<T>(x, key));
+				case Sort<T>.Conglomerate(var keys):
+					IOrderedQueryable<T> nQuery = Sort(query, keys[0]);
+					foreach ((string key, bool desc) in keys.Skip(1))
+					{
+						nQuery = desc
+							? nQuery.ThenByDescending(x => EF.Property<object>(x, key))
+							: nQuery.ThenBy(x => EF.Property<object>(x, key));
+					}
+					return nQuery;
+				default:
+					// The language should not require me to do this...
+					throw new SwitchExpressionException();
+			}
+		}
+
+		private static Func<Expression, Expression, BinaryExpression> GetComparisonExpression(
+				bool desc,
+				bool next,
+				bool orEqual)
+		{
+			bool greaterThan = desc ^ next;
+
+			return orEqual
+				? (greaterThan ? Expression.GreaterThanOrEqual : Expression.LessThanOrEqual)
+				: (greaterThan ? Expression.GreaterThan : Expression.LessThan);
+		}
+
+
+		/// <summary>
+		/// Create a filter (where) expression on the query to skip everything before/after the referenceID.
+		/// The generalized expression for this in pseudocode is:
+		///   (x > a) OR
+		///   (x = a AND y > b) OR
+		///   (x = a AND y = b AND z > c) OR...
+		///
+		/// Of course, this will be a bit more complex when ASC and DESC are mixed.
+		/// Assume x is ASC, y is DESC, and z is ASC:
+		///   (x > a) OR
+		///   (x = a AND y &lt; b) OR
+		///   (x = a AND y = b AND z > c) OR...
+		/// </summary>
+		protected Expression<Func<T, bool>> KeysetPaginatate(
+			Sort<T> sort,
+			T reference,
+			bool next = true)
+		{
+			if (sort is Sort<T>.Default)
+				sort = DefaultSort;
+
+			// x =>
+			ParameterExpression x = Expression.Parameter(typeof(T), "x");
+			ConstantExpression referenceC = Expression.Constant(reference, typeof(T));
+
+			if (sort is Sort<T>.By(var key, var desc))
+			{
+				Func<Expression, Expression, BinaryExpression> comparer = GetComparisonExpression(desc, next, false);
+				MemberExpression xkey = Expression.Property(x, key);
+				MemberExpression rkey = Expression.Property(referenceC, key);
+				BinaryExpression compare = ApiHelper.StringCompatibleExpression(comparer, xkey, rkey);
+				return Expression.Lambda<Func<T, bool>>(compare, x);
+			}
+
+			if (sort is Sort<T>.Conglomerate(var list))
+			{
+				throw new NotImplementedException();
+				// BinaryExpression orExpression;
+				//
+				// foreach ((string key, bool desc) in list)
+				// {
+				// 	query.Where(x =>
+				// }
+			}
+			throw new SwitchExpressionException();
+
+			// Shamlessly stollen from https://github.com/mrahhal/MR.EntityFrameworkCore.KeysetPagination/blob/main/src/MR.EntityFrameworkCore.KeysetPagination/KeysetPaginationExtensions.cs#L191
+			// // A composite keyset pagination in sql looks something like this:
+			// //   (x, y, ...) > (a, b, ...)
+			// // Where, x/y/... represent the column and a/b/... represent the reference's respective values.
+			// //
+			// // In sql standard this syntax is called "row value". Check here: https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-row-values
+			// // Unfortunately, not all databases support this properly.
+			// // Further, if we were to use this we would somehow need EF Core to recognise it and translate it
+			// // perhaps by using a new DbFunction (https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbfunctions).
+			// // There's an ongoing issue for this here: https://github.com/dotnet/efcore/issues/26822
+			// //
+			// // In addition, row value won't work for mixed ordered columns. i.e if x > a but y < b.
+			// // So even if we can use it we'll still have to fallback to this logic in these cases.
+			// //
+			// // The generalized expression for this in pseudocode is:
+			// //   (x > a) OR
+			// //   (x = a AND y > b) OR
+			// //   (x = a AND y = b AND z > c) OR...
+			// //
+			// // Of course, this will be a bit more complex when ASC and DESC are mixed.
+			// // Assume x is ASC, y is DESC, and z is ASC:
+			// //   (x > a) OR
+			// //   (x = a AND y < b) OR
+			// //   (x = a AND y = b AND z > c) OR...
+			// //
+			// // An optimization is to include an additional redundant wrapping clause for the 1st column when there are
+			// // more than one column we're acting on, which would allow the db to use it as an access predicate on the 1st column.
+			// // See here: https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-equivalent-logic
+			//
+			// var referenceValues = GetValues(columns, reference);
+			//
+			// MemberExpression firstMemberAccessExpression;
+			// Expression firstReferenceValueExpression;
+			//
+			// // entity =>
+			// ParameterExpression param = Expression.Parameter(typeof(T), "entity");
+			//
+			// BinaryExpression orExpression;
+			// int innerLimit = 1;
+			// // This loop compounds the outer OR expressions.
+			// for (int i = 0; i < sort.list.Length; i++)
+			// {
+			// 	BinaryExpression andExpression;
+			//
+			// 	// This loop compounds the inner AND expressions.
+			// 	// innerLimit implicitly grows from 1 to items.Count by each iteration.
+			// 	for (int j = 0; j < innerLimit; j++)
+			// 	{
+			// 		bool isInnerLastOperation = j + 1 == innerLimit;
+			// 		var column = columns[j];
+			// 		var memberAccess = column.MakeMemberAccessExpression(param);
+			// 		var referenceValue = referenceValues[j];
+			// 		Expression<Func<object>> referenceValueFunc = () => referenceValue;
+			// 		var referenceValueExpression = referenceValueFunc.Body;
+			//
+			// 		if (firstMemberAccessExpression == null)
+			// 		{
+			// 			// This might be used later on in an optimization.
+			// 			firstMemberAccessExpression = memberAccess;
+			// 			firstReferenceValueExpression = referenceValueExpression;
+			// 		}
+			//
+			// 		BinaryExpression innerExpression;
+			// 		if (!isInnerLastOperation)
+			// 		{
+			// 			innerExpression = Expression.Equal(
+			// 				memberAccess,
+			// 				EnsureMatchingType(memberAccess, referenceValueExpression));
+			// 		}
+			// 		else
+			// 		{
+			// 			var compare = GetComparisonExpressionToApply(direction, column, orEqual: false);
+			// 			innerExpression = MakeComparisonExpression(
+			// 				column,
+			// 				memberAccess, referenceValueExpression,
+			// 				compare);
+			// 		}
+			//
+			// 		andExpression = andExpression == null ? innerExpression : Expression.And(andExpression, innerExpression);
+			// 	}
+			//
+			// 	orExpression = orExpression == null ? andExpression : Expression.Or(orExpression, andExpression);
+			//
+			// 	innerLimit++;
+			// }
+			//
+			// var finalExpression = orExpression;
+			// if (columns.Count > 1)
+			// {
+			// 	// Implement the optimization that allows an access predicate on the 1st column.
+			// 	// This is done by generating the following expression:
+			// 	//   (x >=|<= a) AND (previous generated expression)
+			// 	//
+			// 	// This effectively adds a redundant clause on the 1st column, but it's a clause all dbs
+			// 	// understand and can use as an access predicate (most commonly when the column is indexed).
+			//
+			// 	var firstColumn = columns[0];
+			// 	var compare = GetComparisonExpressionToApply(direction, firstColumn, orEqual: true);
+			// 	var accessPredicateClause = MakeComparisonExpression(
+			// 		firstColumn,
+			// 		firstMemberAccessExpression!, firstReferenceValueExpression!,
+			// 		compare);
+			// 	finalExpression = Expression.And(accessPredicateClause, finalExpression);
+			// }
+			//
+			// return Expression.Lambda<Func<T, bool>>(finalExpression, param);
+		}
 
 		/// <summary>
 		/// Get a resource from it's ID and make the <see cref="Database"/> instance track it.
@@ -117,10 +318,7 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public virtual Task<T> GetOrDefault(Expression<Func<T, bool>> where, Sort<T> sortBy = default)
 		{
-			IQueryable<T> query = Database.Set<T>();
-			Expression<Func<T, object>> sortKey = sortBy.Key ?? DefaultSort;
-			query = sortBy.Descendant ? query.OrderByDescending(sortKey) : query.OrderBy(sortKey);
-			return query.FirstOrDefaultAsync(where);
+			return Sort(Database.Set<T>(), sortBy).FirstOrDefaultAsync(where);
 		}
 
 		/// <inheritdoc/>
@@ -142,54 +340,19 @@ namespace Kyoo.Core.Controllers
 		/// <param name="sort">The sort settings (sort order and sort by)</param>
 		/// <param name="limit">Pagination information (where to start and how many to get)</param>
 		/// <returns>The filtered query</returns>
-		protected Task<ICollection<T>> ApplyFilters(IQueryable<T> query,
+		protected async Task<ICollection<T>> ApplyFilters(IQueryable<T> query,
 			Expression<Func<T, bool>> where = null,
 			Sort<T> sort = default,
 			Pagination limit = default)
 		{
-			return ApplyFilters(query, GetOrDefault, DefaultSort, where, sort, limit);
-		}
-
-		/// <summary>
-		/// Apply filters to a query to ease sort, pagination and where queries for any resources types.
-		/// For resources of type <typeparamref name="T"/>, see <see cref="ApplyFilters"/>
-		/// </summary>
-		/// <param name="query">The base query to filter.</param>
-		/// <param name="get">A function to asynchronously get a resource from the database using it's ID.</param>
-		/// <param name="defaultSort">The default sort order of this resource's type.</param>
-		/// <param name="where">An expression to filter based on arbitrary conditions</param>
-		/// <param name="sort">The sort settings (sort order and sort by)</param>
-		/// <param name="limit">Pagination information (where to start and how many to get)</param>
-		/// <typeparam name="TValue">The type of items to query.</typeparam>
-		/// <returns>The filtered query</returns>
-		protected async Task<ICollection<TValue>> ApplyFilters<TValue>(IQueryable<TValue> query,
-			Func<int, Task<TValue>> get,
-			Expression<Func<TValue, object>> defaultSort,
-			Expression<Func<TValue, bool>> where = null,
-			Sort<TValue> sort = default,
-			Pagination limit = default)
-		{
+			query = Sort(query, sort);
 			if (where != null)
 				query = query.Where(where);
 
-			Expression<Func<TValue, object>> sortKey = sort.Key ?? defaultSort;
-			Expression sortExpression = sortKey.Body.NodeType == ExpressionType.Convert
-				? ((UnaryExpression)sortKey.Body).Operand
-				: sortKey.Body;
-
-			if (typeof(Enum).IsAssignableFrom(sortExpression.Type))
-				throw new ArgumentException("Invalid sort key.");
-
-			query = sort.Descendant ? query.OrderByDescending(sortKey) : query.OrderBy(sortKey);
-
 			if (limit.AfterID != null)
 			{
-				TValue after = await get(limit.AfterID.Value);
-				Expression key = Expression.Constant(sortKey.Compile()(after), sortExpression.Type);
-				query = query.Where(Expression.Lambda<Func<TValue, bool>>(
-					ApiHelper.StringCompatibleExpression(Expression.GreaterThan, sortExpression, key),
-					sortKey.Parameters.First()
-				));
+				T reference = await Get(limit.AfterID.Value);
+				query = query.Where(KeysetPaginatate(sort, reference));
 			}
 			if (limit.Count > 0)
 				query = query.Take(limit.Count);

--- a/back/src/Kyoo.Core/Controllers/Repositories/LocalRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/LocalRepository.cs
@@ -140,6 +140,8 @@ namespace Kyoo.Core.Controllers
 			T reference,
 			bool next = true)
 		{
+			sort ??= DefaultSort;
+
 			// x =>
 			ParameterExpression x = Expression.Parameter(typeof(T), "x");
 			ConstantExpression referenceC = Expression.Constant(reference, typeof(T));
@@ -284,12 +286,14 @@ namespace Kyoo.Core.Controllers
 			if (where != null)
 				query = query.Where(where);
 
-			if (limit.AfterID != null)
+			if (limit?.AfterID != null)
 			{
 				T reference = await Get(limit.AfterID.Value);
 				query = query.Where(KeysetPaginatate(sort, reference, !limit.Reverse));
 			}
-			if (limit.Limit > 0)
+			if (limit?.Reverse == true)
+				query = query.Reverse();
+			if (limit?.Limit > 0)
 				query = query.Take(limit.Limit);
 
 			return await query.ToListAsync();

--- a/back/src/Kyoo.Core/Controllers/Repositories/LocalRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/LocalRepository.cs
@@ -72,33 +72,37 @@ namespace Kyoo.Core.Controllers
 		{
 			sortBy ??= DefaultSort;
 
-			switch (sortBy)
+			IOrderedQueryable<T> _Sort(IQueryable<T> query, Sort<T> sortBy)
 			{
-				case Sort<T>.Default:
-					return Sort(query, DefaultSort);
-				case Sort<T>.By(var key, var desc):
-					return desc
-						? query.OrderByDescending(x => EF.Property<object>(x, key))
-						: query.OrderBy(x => EF.Property<T>(x, key));
-				case Sort<T>.Conglomerate(var keys):
-					IOrderedQueryable<T> nQuery = Sort(query, keys[0]);
-					foreach ((string key, bool desc) in keys.Skip(1))
-					{
-						nQuery = desc
-							? nQuery.ThenByDescending(x => EF.Property<object>(x, key))
-							: nQuery.ThenBy(x => EF.Property<object>(x, key));
-					}
-					return nQuery;
-				default:
-					// The language should not require me to do this...
-					throw new SwitchExpressionException();
+				switch (sortBy)
+				{
+					case Sort<T>.Default:
+						return Sort(query, DefaultSort);
+					case Sort<T>.By(var key, var desc):
+						return desc
+							? query.OrderByDescending(x => EF.Property<object>(x, key))
+							: query.OrderBy(x => EF.Property<T>(x, key));
+					case Sort<T>.Conglomerate(var keys):
+						IOrderedQueryable<T> nQuery = _Sort(query, keys[0]);
+						foreach ((string key, bool desc) in keys.Skip(1))
+						{
+							nQuery = desc
+								? nQuery.ThenByDescending(x => EF.Property<object>(x, key))
+								: nQuery.ThenBy(x => EF.Property<object>(x, key));
+						}
+						return nQuery;
+					default:
+						// The language should not require me to do this...
+						throw new SwitchExpressionException();
+				}
 			}
+			return _Sort(query, sortBy).ThenBy(x => x.ID);
 		}
 
-		private static Func<Expression, Expression, BinaryExpression> GetComparisonExpression(
-				bool desc,
-				bool next,
-				bool orEqual)
+		private static Func<Expression, Expression, BinaryExpression> _GetComparisonExpression(
+			bool desc,
+			bool next,
+			bool orEqual)
 		{
 			bool greaterThan = desc ^ next;
 
@@ -106,7 +110,6 @@ namespace Kyoo.Core.Controllers
 				? (greaterThan ? Expression.GreaterThanOrEqual : Expression.LessThanOrEqual)
 				: (greaterThan ? Expression.GreaterThan : Expression.LessThan);
 		}
-
 
 		/// <summary>
 		/// Create a filter (where) expression on the query to skip everything before/after the referenceID.
@@ -121,6 +124,10 @@ namespace Kyoo.Core.Controllers
 		///   (x = a AND y &lt; b) OR
 		///   (x = a AND y = b AND z > c) OR...
 		/// </summary>
+		/// <param name="sort">How items are sorted in the query</param>
+		/// <param name="reference">The reference item (the AfterID query)</param>
+		/// <param name="next">True if the following page should be returned, false for the previous.</param>
+		/// <returns>An expression ready to be added to a Where close of a sorted query to handle the AfterID</returns>
 		protected Expression<Func<T, bool>> KeysetPaginatate(
 			Sort<T> sort,
 			T reference,
@@ -133,133 +140,52 @@ namespace Kyoo.Core.Controllers
 			ParameterExpression x = Expression.Parameter(typeof(T), "x");
 			ConstantExpression referenceC = Expression.Constant(reference, typeof(T));
 
-			if (sort is Sort<T>.By(var key, var desc))
+			// Don't forget that every sorts must end with a ID sort (to differenciate equalities).
+			Sort<T>.By id = new(x => x.ID);
+
+			IEnumerable<Sort<T>.By> sorts = (sort switch
 			{
-				Func<Expression, Expression, BinaryExpression> comparer = GetComparisonExpression(desc, next, false);
+				Sort<T>.By @sortBy => new[] { sortBy },
+				Sort<T>.Conglomerate(var list) => list,
+				_ => Array.Empty<Sort<T>.By>(),
+			}).Append(id);
+
+			BinaryExpression filter = null;
+			List<Sort<T>.By> previousSteps = new();
+			// TODO: Add an outer query >= for perf
+			// PERF: See https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-equivalent-logic
+			foreach ((string key, bool desc) in sorts)
+			{
+				BinaryExpression compare = null;
+
+				// Create all the equality statements for previous sorts.
+				foreach ((string pKey, bool pDesc) in previousSteps)
+				{
+					BinaryExpression pcompare = Expression.Equal(
+						Expression.Property(x, pKey),
+						Expression.Property(referenceC, pKey)
+					);
+					compare = compare != null
+						? Expression.AndAlso(compare, pcompare)
+						: pcompare;
+				}
+
+				// Create the last comparison of the statement.
+				Func<Expression, Expression, BinaryExpression> comparer = _GetComparisonExpression(desc, next, false);
 				MemberExpression xkey = Expression.Property(x, key);
 				MemberExpression rkey = Expression.Property(referenceC, key);
-				BinaryExpression compare = ApiHelper.StringCompatibleExpression(comparer, xkey, rkey);
-				return Expression.Lambda<Func<T, bool>>(compare, x);
-			}
+				BinaryExpression lastCompare = ApiHelper.StringCompatibleExpression(comparer, xkey, rkey);
+				compare = compare != null
+					? Expression.AndAlso(compare, lastCompare)
+					: lastCompare;
 
-			if (sort is Sort<T>.Conglomerate(var list))
-			{
-				throw new NotImplementedException();
-				// BinaryExpression orExpression;
-				//
-				// foreach ((string key, bool desc) in list)
-				// {
-				// 	query.Where(x =>
-				// }
-			}
-			throw new SwitchExpressionException();
+				filter = filter != null
+					? Expression.OrElse(filter, compare)
+					: compare;
 
-			// Shamlessly stollen from https://github.com/mrahhal/MR.EntityFrameworkCore.KeysetPagination/blob/main/src/MR.EntityFrameworkCore.KeysetPagination/KeysetPaginationExtensions.cs#L191
-			// // A composite keyset pagination in sql looks something like this:
-			// //   (x, y, ...) > (a, b, ...)
-			// // Where, x/y/... represent the column and a/b/... represent the reference's respective values.
-			// //
-			// // In sql standard this syntax is called "row value". Check here: https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-row-values
-			// // Unfortunately, not all databases support this properly.
-			// // Further, if we were to use this we would somehow need EF Core to recognise it and translate it
-			// // perhaps by using a new DbFunction (https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbfunctions).
-			// // There's an ongoing issue for this here: https://github.com/dotnet/efcore/issues/26822
-			// //
-			// // In addition, row value won't work for mixed ordered columns. i.e if x > a but y < b.
-			// // So even if we can use it we'll still have to fallback to this logic in these cases.
-			// //
-			// // The generalized expression for this in pseudocode is:
-			// //   (x > a) OR
-			// //   (x = a AND y > b) OR
-			// //   (x = a AND y = b AND z > c) OR...
-			// //
-			// // Of course, this will be a bit more complex when ASC and DESC are mixed.
-			// // Assume x is ASC, y is DESC, and z is ASC:
-			// //   (x > a) OR
-			// //   (x = a AND y < b) OR
-			// //   (x = a AND y = b AND z > c) OR...
-			// //
-			// // An optimization is to include an additional redundant wrapping clause for the 1st column when there are
-			// // more than one column we're acting on, which would allow the db to use it as an access predicate on the 1st column.
-			// // See here: https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-equivalent-logic
-			//
-			// var referenceValues = GetValues(columns, reference);
-			//
-			// MemberExpression firstMemberAccessExpression;
-			// Expression firstReferenceValueExpression;
-			//
-			// // entity =>
-			// ParameterExpression param = Expression.Parameter(typeof(T), "entity");
-			//
-			// BinaryExpression orExpression;
-			// int innerLimit = 1;
-			// // This loop compounds the outer OR expressions.
-			// for (int i = 0; i < sort.list.Length; i++)
-			// {
-			// 	BinaryExpression andExpression;
-			//
-			// 	// This loop compounds the inner AND expressions.
-			// 	// innerLimit implicitly grows from 1 to items.Count by each iteration.
-			// 	for (int j = 0; j < innerLimit; j++)
-			// 	{
-			// 		bool isInnerLastOperation = j + 1 == innerLimit;
-			// 		var column = columns[j];
-			// 		var memberAccess = column.MakeMemberAccessExpression(param);
-			// 		var referenceValue = referenceValues[j];
-			// 		Expression<Func<object>> referenceValueFunc = () => referenceValue;
-			// 		var referenceValueExpression = referenceValueFunc.Body;
-			//
-			// 		if (firstMemberAccessExpression == null)
-			// 		{
-			// 			// This might be used later on in an optimization.
-			// 			firstMemberAccessExpression = memberAccess;
-			// 			firstReferenceValueExpression = referenceValueExpression;
-			// 		}
-			//
-			// 		BinaryExpression innerExpression;
-			// 		if (!isInnerLastOperation)
-			// 		{
-			// 			innerExpression = Expression.Equal(
-			// 				memberAccess,
-			// 				EnsureMatchingType(memberAccess, referenceValueExpression));
-			// 		}
-			// 		else
-			// 		{
-			// 			var compare = GetComparisonExpressionToApply(direction, column, orEqual: false);
-			// 			innerExpression = MakeComparisonExpression(
-			// 				column,
-			// 				memberAccess, referenceValueExpression,
-			// 				compare);
-			// 		}
-			//
-			// 		andExpression = andExpression == null ? innerExpression : Expression.And(andExpression, innerExpression);
-			// 	}
-			//
-			// 	orExpression = orExpression == null ? andExpression : Expression.Or(orExpression, andExpression);
-			//
-			// 	innerLimit++;
-			// }
-			//
-			// var finalExpression = orExpression;
-			// if (columns.Count > 1)
-			// {
-			// 	// Implement the optimization that allows an access predicate on the 1st column.
-			// 	// This is done by generating the following expression:
-			// 	//   (x >=|<= a) AND (previous generated expression)
-			// 	//
-			// 	// This effectively adds a redundant clause on the 1st column, but it's a clause all dbs
-			// 	// understand and can use as an access predicate (most commonly when the column is indexed).
-			//
-			// 	var firstColumn = columns[0];
-			// 	var compare = GetComparisonExpressionToApply(direction, firstColumn, orEqual: true);
-			// 	var accessPredicateClause = MakeComparisonExpression(
-			// 		firstColumn,
-			// 		firstMemberAccessExpression!, firstReferenceValueExpression!,
-			// 		compare);
-			// 	finalExpression = Expression.And(accessPredicateClause, finalExpression);
-			// }
-			//
-			// return Expression.Lambda<Func<T, bool>>(finalExpression, param);
+				previousSteps.Add(new(key, desc));
+			}
+			return Expression.Lambda<Func<T, bool>>(filter, x);
 		}
 
 		/// <summary>

--- a/back/src/Kyoo.Core/Controllers/Repositories/PeopleRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/PeopleRepository.cs
@@ -85,7 +85,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated people (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/PeopleRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/PeopleRepository.cs
@@ -148,7 +148,7 @@ namespace Kyoo.Core.Controllers
 		}
 
 		/// <inheritdoc />
-		public async Task<ICollection<PeopleRole>> GetFromShow(int showID,
+		public Task<ICollection<PeopleRole>> GetFromShow(int showID,
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)
@@ -169,7 +169,7 @@ namespace Kyoo.Core.Controllers
 		}
 
 		/// <inheritdoc />
-		public async Task<ICollection<PeopleRole>> GetFromShow(string showSlug,
+		public Task<ICollection<PeopleRole>> GetFromShow(string showSlug,
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)
@@ -192,7 +192,7 @@ namespace Kyoo.Core.Controllers
 		}
 
 		/// <inheritdoc />
-		public async Task<ICollection<PeopleRole>> GetFromPeople(int id,
+		public Task<ICollection<PeopleRole>> GetFromPeople(int id,
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)
@@ -212,7 +212,7 @@ namespace Kyoo.Core.Controllers
 		}
 
 		/// <inheritdoc />
-		public async Task<ICollection<PeopleRole>> GetFromPeople(string slug,
+		public Task<ICollection<PeopleRole>> GetFromPeople(string slug,
 			Expression<Func<PeopleRole, bool>> where = null,
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)

--- a/back/src/Kyoo.Core/Controllers/Repositories/PeopleRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/PeopleRepository.cs
@@ -51,7 +51,7 @@ namespace Kyoo.Core.Controllers
 		private readonly Lazy<IShowRepository> _shows;
 
 		/// <inheritdoc />
-		protected override Expression<Func<People, object>> DefaultSort => x => x.Name;
+		protected override Sort<People> DefaultSort => new Sort<People>.By(x => x.Name);
 
 		/// <summary>
 		/// Create a new <see cref="PeopleRepository"/>
@@ -72,9 +72,10 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public override async Task<ICollection<People>> Search(string query)
 		{
-			return await _database.People
-				.Where(_database.Like<People>(x => x.Name, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.People
+					.Where(_database.Like<People>(x => x.Name, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}
@@ -152,19 +153,19 @@ namespace Kyoo.Core.Controllers
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)
 		{
-			ICollection<PeopleRole> people = await ApplyFilters(_database.PeopleRoles
-					.Where(x => x.ShowID == showID)
-					.Include(x => x.People),
-				id => _database.PeopleRoles.FirstOrDefaultAsync(x => x.ID == id),
-				x => x.People.Name,
-				where,
-				sort,
-				limit);
-			if (!people.Any() && await _shows.Value.GetOrDefault(showID) == null)
-				throw new ItemNotFoundException();
-			foreach (PeopleRole role in people)
-				role.ForPeople = true;
-			return people;
+			throw new NotImplementedException();
+			// ICollection<PeopleRole> people = await ApplyFilters(_database.PeopleRoles
+			// 		.Where(x => x.ShowID == showID)
+			// 		.Include(x => x.People),
+			// 	x => x.People.Name,
+			// 	where,
+			// 	sort,
+			// 	limit);
+			// if (!people.Any() && await _shows.Value.GetOrDefault(showID) == null)
+			// 	throw new ItemNotFoundException();
+			// foreach (PeopleRole role in people)
+			// 	role.ForPeople = true;
+			// return people;
 		}
 
 		/// <inheritdoc />
@@ -173,20 +174,21 @@ namespace Kyoo.Core.Controllers
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)
 		{
-			ICollection<PeopleRole> people = await ApplyFilters(_database.PeopleRoles
-					.Where(x => x.Show.Slug == showSlug)
-					.Include(x => x.People)
-					.Include(x => x.Show),
-				id => _database.PeopleRoles.FirstOrDefaultAsync(x => x.ID == id),
-				x => x.People.Name,
-				where,
-				sort,
-				limit);
-			if (!people.Any() && await _shows.Value.GetOrDefault(showSlug) == null)
-				throw new ItemNotFoundException();
-			foreach (PeopleRole role in people)
-				role.ForPeople = true;
-			return people;
+			throw new NotImplementedException();
+			// ICollection<PeopleRole> people = await ApplyFilters(_database.PeopleRoles
+			// 		.Where(x => x.Show.Slug == showSlug)
+			// 		.Include(x => x.People)
+			// 		.Include(x => x.Show),
+			// 	id => _database.PeopleRoles.FirstOrDefaultAsync(x => x.ID == id),
+			// 	x => x.People.Name,
+			// 	where,
+			// 	sort,
+			// 	limit);
+			// if (!people.Any() && await _shows.Value.GetOrDefault(showSlug) == null)
+			// 	throw new ItemNotFoundException();
+			// foreach (PeopleRole role in people)
+			// 	role.ForPeople = true;
+			// return people;
 		}
 
 		/// <inheritdoc />
@@ -195,17 +197,18 @@ namespace Kyoo.Core.Controllers
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)
 		{
-			ICollection<PeopleRole> roles = await ApplyFilters(_database.PeopleRoles
-					.Where(x => x.PeopleID == id)
-					.Include(x => x.Show),
-				y => _database.PeopleRoles.FirstOrDefaultAsync(x => x.ID == y),
-				x => x.Show.Title,
-				where,
-				sort,
-				limit);
-			if (!roles.Any() && await GetOrDefault(id) == null)
-				throw new ItemNotFoundException();
-			return roles;
+			throw new NotImplementedException();
+			// ICollection<PeopleRole> roles = await ApplyFilters(_database.PeopleRoles
+			// 		.Where(x => x.PeopleID == id)
+			// 		.Include(x => x.Show),
+			// 	y => _database.PeopleRoles.FirstOrDefaultAsync(x => x.ID == y),
+			// 	x => x.Show.Title,
+			// 	where,
+			// 	sort,
+			// 	limit);
+			// if (!roles.Any() && await GetOrDefault(id) == null)
+			// 	throw new ItemNotFoundException();
+			// return roles;
 		}
 
 		/// <inheritdoc />
@@ -214,17 +217,18 @@ namespace Kyoo.Core.Controllers
 			Sort<PeopleRole> sort = default,
 			Pagination limit = default)
 		{
-			ICollection<PeopleRole> roles = await ApplyFilters(_database.PeopleRoles
-					.Where(x => x.People.Slug == slug)
-					.Include(x => x.Show),
-				id => _database.PeopleRoles.FirstOrDefaultAsync(x => x.ID == id),
-				x => x.Show.Title,
-				where,
-				sort,
-				limit);
-			if (!roles.Any() && await GetOrDefault(slug) == null)
-				throw new ItemNotFoundException();
-			return roles;
+			throw new NotImplementedException();
+			// ICollection<PeopleRole> roles = await ApplyFilters(_database.PeopleRoles
+			// 		.Where(x => x.People.Slug == slug)
+			// 		.Include(x => x.Show),
+			// 	id => _database.PeopleRoles.FirstOrDefaultAsync(x => x.ID == id),
+			// 	x => x.Show.Title,
+			// 	where,
+			// 	sort,
+			// 	limit);
+			// if (!roles.Any() && await GetOrDefault(slug) == null)
+			// 	throw new ItemNotFoundException();
+			// return roles;
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Controllers/Repositories/ProviderRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/ProviderRepository.cs
@@ -82,19 +82,15 @@ namespace Kyoo.Core.Controllers
 		}
 
 		/// <inheritdoc />
-		public Task<ICollection<MetadataID>> GetMetadataID<T>(Expression<Func<MetadataID, bool>> where = null,
+		public async Task<ICollection<MetadataID>> GetMetadataID<T>(Expression<Func<MetadataID, bool>> where = null,
 			Sort<MetadataID> sort = default,
 			Pagination limit = default)
 			where T : class, IMetadata
 		{
-			throw new NotImplementedException();
-			// return ApplyFilters(_database.MetadataIds<T>()
-			// 		.Include(y => y.Provider),
-			// 	x => _database.MetadataIds<T>().FirstOrDefaultAsync(y => y.ResourceID == x),
-			// 	x => x.ResourceID,
-			// 	where,
-			// 	sort,
-			// 	limit);
+			return await _database.MetadataIds<T>()
+				.Include(y => y.Provider)
+				.Where(where)
+				.ToListAsync();
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Controllers/Repositories/ProviderRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/ProviderRepository.cs
@@ -49,14 +49,15 @@ namespace Kyoo.Core.Controllers
 		}
 
 		/// <inheritdoc />
-		protected override Expression<Func<Provider, object>> DefaultSort => x => x.Slug;
+		protected override Sort<Provider> DefaultSort => new Sort<Provider>.By(x => x.Slug);
 
 		/// <inheritdoc />
 		public override async Task<ICollection<Provider>> Search(string query)
 		{
-			return await _database.Providers
-				.Where(_database.Like<Provider>(x => x.Name, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.Providers
+					.Where(_database.Like<Provider>(x => x.Name, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}
@@ -87,13 +88,14 @@ namespace Kyoo.Core.Controllers
 			Pagination limit = default)
 			where T : class, IMetadata
 		{
-			return ApplyFilters(_database.MetadataIds<T>()
-					.Include(y => y.Provider),
-				x => _database.MetadataIds<T>().FirstOrDefaultAsync(y => y.ResourceID == x),
-				x => x.ResourceID,
-				where,
-				sort,
-				limit);
+			throw new NotImplementedException();
+			// return ApplyFilters(_database.MetadataIds<T>()
+			// 		.Include(y => y.Provider),
+			// 	x => _database.MetadataIds<T>().FirstOrDefaultAsync(y => y.ResourceID == x),
+			// 	x => x.ResourceID,
+			// 	where,
+			// 	sort,
+			// 	limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Controllers/Repositories/ProviderRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/ProviderRepository.cs
@@ -67,8 +67,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync("Trying to insert a duplicated provider " +
-				$"(slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/SeasonRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/SeasonRepository.cs
@@ -45,7 +45,7 @@ namespace Kyoo.Core.Controllers
 		private readonly IProviderRepository _providers;
 
 		/// <inheritdoc/>
-		protected override Expression<Func<Season, object>> DefaultSort => x => x.SeasonNumber;
+		protected override Sort<Season> DefaultSort => new Sort<Season>.By(x => x.SeasonNumber);
 
 		/// <summary>
 		/// Create a new <see cref="SeasonRepository"/>.
@@ -95,9 +95,10 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc/>
 		public override async Task<ICollection<Season>> Search(string query)
 		{
-			return await _database.Seasons
-				.Where(_database.Like<Season>(x => x.Title, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.Seasons
+					.Where(_database.Like<Season>(x => x.Title, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}

--- a/back/src/Kyoo.Core/Controllers/Repositories/SeasonRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/SeasonRepository.cs
@@ -108,7 +108,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated season (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/ShowRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/ShowRepository.cs
@@ -101,7 +101,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated show (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/ShowRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/ShowRepository.cs
@@ -60,7 +60,7 @@ namespace Kyoo.Core.Controllers
 		private readonly IProviderRepository _providers;
 
 		/// <inheritdoc />
-		protected override Expression<Func<Show, object>> DefaultSort => x => x.Title;
+		protected override Sort<Show> DefaultSort => new Sort<Show>.By(x => x.Title);
 
 		/// <summary>
 		/// Create a new <see cref="ShowRepository"/>.
@@ -88,9 +88,10 @@ namespace Kyoo.Core.Controllers
 		public override async Task<ICollection<Show>> Search(string query)
 		{
 			query = $"%{query}%";
-			return await _database.Shows
-				.Where(_database.Like<Show>(x => x.Title + " " + x.Slug, query))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.Shows
+					.Where(_database.Like<Show>(x => x.Title + " " + x.Slug, query))
+				)
 				.Take(20)
 				.ToListAsync();
 		}

--- a/back/src/Kyoo.Core/Controllers/Repositories/StudioRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/StudioRepository.cs
@@ -44,7 +44,7 @@ namespace Kyoo.Core.Controllers
 		private readonly IProviderRepository _providers;
 
 		/// <inheritdoc />
-		protected override Expression<Func<Studio, object>> DefaultSort => x => x.Name;
+		protected override Sort<Studio> DefaultSort => new Sort<Studio>.By(x => x.Name);
 
 		/// <summary>
 		/// Create a new <see cref="StudioRepository"/>.
@@ -61,9 +61,10 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public override async Task<ICollection<Studio>> Search(string query)
 		{
-			return await _database.Studios
-				.Where(_database.Like<Studio>(x => x.Name, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.Studios
+					.Where(_database.Like<Studio>(x => x.Name, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}

--- a/back/src/Kyoo.Core/Controllers/Repositories/StudioRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/StudioRepository.cs
@@ -74,7 +74,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated studio (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/TrackRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/TrackRepository.cs
@@ -18,7 +18,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Kyoo.Abstractions.Controllers;
 using Kyoo.Abstractions.Models;
@@ -38,7 +37,7 @@ namespace Kyoo.Core.Controllers
 		private readonly DatabaseContext _database;
 
 		/// <inheritdoc />
-		protected override Expression<Func<Track, object>> DefaultSort => x => x.TrackIndex;
+		protected override Sort<Track> DefaultSort => new Sort<Track>.By(x => x.TrackIndex);
 
 		/// <summary>
 		/// Create a new <see cref="TrackRepository"/>.

--- a/back/src/Kyoo.Core/Controllers/Repositories/UserRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/UserRepository.cs
@@ -67,7 +67,7 @@ namespace Kyoo.Core.Controllers
 		{
 			await base.Create(obj);
 			_database.Entry(obj).State = EntityState.Added;
-			await _database.SaveChangesAsync($"Trying to insert a duplicated user (slug {obj.Slug} already exists).");
+			await _database.SaveChangesAsync(() => Get(obj.Slug));
 			return obj;
 		}
 

--- a/back/src/Kyoo.Core/Controllers/Repositories/UserRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/UserRepository.cs
@@ -39,7 +39,7 @@ namespace Kyoo.Core.Controllers
 		private readonly DatabaseContext _database;
 
 		/// <inheritdoc />
-		protected override Expression<Func<User, object>> DefaultSort => x => x.Username;
+		protected override Sort<User> DefaultSort => new Sort<User>.By(x => x.Username);
 
 		/// <summary>
 		/// Create a new <see cref="UserRepository"/>
@@ -54,9 +54,10 @@ namespace Kyoo.Core.Controllers
 		/// <inheritdoc />
 		public override async Task<ICollection<User>> Search(string query)
 		{
-			return await _database.Users
-				.Where(_database.Like<User>(x => x.Username, $"%{query}%"))
-				.OrderBy(DefaultSort)
+			return await Sort(
+				_database.Users
+					.Where(_database.Like<User>(x => x.Username, $"%{query}%"))
+				)
 				.Take(20)
 				.ToListAsync();
 		}

--- a/back/src/Kyoo.Core/CoreModule.cs
+++ b/back/src/Kyoo.Core/CoreModule.cs
@@ -34,7 +34,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using IMetadataProvider = Kyoo.Abstractions.Controllers.IMetadataProvider;
 using JsonOptions = Kyoo.Core.Api.JsonOptions;
@@ -122,7 +121,10 @@ namespace Kyoo.Core
 			services.AddHttpContextAccessor();
 			services.AddTransient<IConfigureOptions<MvcNewtonsoftJsonOptions>, JsonOptions>();
 
-			services.AddMvcCore()
+			services.AddMvcCore(options =>
+				{
+					options.Filters.Add<ExceptionFilter>();
+				})
 				.AddNewtonsoftJson()
 				.AddDataAnnotations()
 				.AddControllersAsServices()
@@ -156,16 +158,7 @@ namespace Kyoo.Core
 		/// <inheritdoc />
 		public IEnumerable<IStartupAction> ConfigureSteps => new IStartupAction[]
 		{
-			SA.New<IApplicationBuilder, IHostEnvironment>((app, env) =>
-			{
-				if (env.IsDevelopment())
-					app.UseDeveloperExceptionPage();
-				else
-				{
-					app.UseExceptionHandler("/error");
-					app.UseHsts();
-				}
-			}, SA.Before),
+			SA.New<IApplicationBuilder>(app => app.UseHsts(), SA.Before),
 			SA.New<IApplicationBuilder>(app => app.UseResponseCompression(), SA.Routing + 1),
 			SA.New<IApplicationBuilder>(app => app.UseRouting(), SA.Routing),
 			SA.New<IApplicationBuilder>(app => app.UseEndpoints(x => x.MapControllers()), SA.Endpoint)

--- a/back/src/Kyoo.Core/CoreModule.cs
+++ b/back/src/Kyoo.Core/CoreModule.cs
@@ -84,6 +84,7 @@ namespace Kyoo.Core
 			builder.RegisterTask<RegisterEpisode>();
 			builder.RegisterTask<RegisterSubtitle>();
 			builder.RegisterTask<MetadataProviderLoader>();
+			builder.RegisterTask<LibraryCreator>();
 
 			static bool DatabaseIsPresent(IComponentRegistryBuilder x)
 				=> x.IsRegistered(new TypedService(typeof(DatabaseContext)));

--- a/back/src/Kyoo.Core/ExceptionFilter.cs
+++ b/back/src/Kyoo.Core/ExceptionFilter.cs
@@ -62,19 +62,19 @@ namespace Kyoo.Core
 					break;
 			}
 		}
-	}
 
-	/// <inheritdoc />
-	public class ServerErrorObjectResult : ObjectResult
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ServerErrorObjectResult"/> class.
-		/// </summary>
-		/// <param name="value">The object to return.</param>
-		public ServerErrorObjectResult(object value)
-			: base(value)
+		/// <inheritdoc />
+		public class ServerErrorObjectResult : ObjectResult
 		{
-			StatusCode = StatusCodes.Status500InternalServerError;
+			/// <summary>
+			/// Initializes a new instance of the <see cref="ServerErrorObjectResult"/> class.
+			/// </summary>
+			/// <param name="value">The object to return.</param>
+			public ServerErrorObjectResult(object value)
+				: base(value)
+			{
+				StatusCode = StatusCodes.Status500InternalServerError;
+			}
 		}
 	}
 }

--- a/back/src/Kyoo.Core/ExceptionFilter.cs
+++ b/back/src/Kyoo.Core/ExceptionFilter.cs
@@ -57,7 +57,7 @@ namespace Kyoo.Core
 					context.Result = new ConflictObjectResult(ex.Existing);
 					break;
 				case Exception ex:
-					_logger.LogError("Unhandled error", ex);
+					_logger.LogError(ex, "Unhandled error");
 					context.Result = new ServerErrorObjectResult(new RequestError("Internal Server Error"));
 					break;
 			}

--- a/back/src/Kyoo.Core/ExceptionFilter.cs
+++ b/back/src/Kyoo.Core/ExceptionFilter.cs
@@ -1,0 +1,80 @@
+// Kyoo - A portable and vast media library solution.
+// Copyright (c) Kyoo.
+//
+// See AUTHORS.md and LICENSE file in the project root for full license information.
+//
+// Kyoo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// Kyoo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Kyoo.Abstractions.Models.Exceptions;
+using Kyoo.Abstractions.Models.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+
+namespace Kyoo.Core
+{
+	/// <summary>
+	/// A middleware to handle errors globally.
+	/// </summary>
+	public class ExceptionFilter : IExceptionFilter
+	{
+		private readonly ILogger _logger;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ExceptionFilter"/> class.
+		/// </summary>
+		/// <param name="logger">The logger used to log errors.</param>
+		public ExceptionFilter(ILogger<ExceptionFilter> logger)
+		{
+			_logger = logger;
+		}
+
+		/// <inheritdoc/>
+		public void OnException(ExceptionContext context)
+		{
+			switch (context.Exception)
+			{
+				case ArgumentException ex:
+					context.Result = new BadRequestObjectResult(new RequestError(ex.Message));
+					break;
+				case ItemNotFoundException ex:
+					context.Result = new NotFoundObjectResult(new RequestError(ex.Message));
+					break;
+				case DuplicatedItemException ex:
+					context.Result = new ConflictObjectResult(ex.Existing);
+					break;
+				case Exception ex:
+					_logger.LogError("Unhandled error", ex);
+					context.Result = new ServerErrorObjectResult(new RequestError("Internal Server Error"));
+					break;
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public class ServerErrorObjectResult : ObjectResult
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ServerErrorObjectResult"/> class.
+		/// </summary>
+		/// <param name="value">The object to return.</param>
+		public ServerErrorObjectResult(object value)
+			: base(value)
+		{
+			StatusCode = StatusCodes.Status500InternalServerError;
+		}
+	}
+}

--- a/back/src/Kyoo.Core/Tasks/LibraryCreator.cs
+++ b/back/src/Kyoo.Core/Tasks/LibraryCreator.cs
@@ -1,0 +1,97 @@
+// Kyoo - A portable and vast media library solution.
+// Copyright (c) Kyoo.
+//
+// See AUTHORS.md and LICENSE file in the project root for full license information.
+//
+// Kyoo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// Kyoo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Kyoo.Abstractions.Controllers;
+using Kyoo.Abstractions.Models;
+using Kyoo.Abstractions.Models.Attributes;
+using Kyoo.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace Kyoo.Core.Tasks
+{
+	/// <summary>
+	/// A task to add new video files.
+	/// </summary>
+	[TaskMetadata("library-creator", "Create libraries", "Create libraries on the library root folder.",
+		RunOnStartup = true, Priority = 500)]
+	public class LibraryCreator : ITask
+	{
+		/// <summary>
+		/// The library manager used to get libraries and providers to use.
+		/// </summary>
+		private readonly ILibraryManager _libraryManager;
+
+		/// <summary>
+		/// A task manager used to create sub tasks for each episode to add to the database.
+		/// </summary>
+		private readonly ITaskManager _taskManager;
+
+		/// <summary>
+		/// The logger used to inform the current status to the console.
+		/// </summary>
+		private readonly ILogger<Crawler> _logger;
+
+		/// <summary>
+		/// Create a new <see cref="Crawler"/>.
+		/// </summary>
+		/// <param name="libraryManager">The library manager to retrieve existing episodes/library/tracks</param>
+		/// <param name="taskManager">The task manager used to start <see cref="RegisterEpisode"/>.</param>
+		/// <param name="logger">The logger used print messages.</param>
+		public LibraryCreator(ILibraryManager libraryManager,
+			ITaskManager taskManager,
+			ILogger<Crawler> logger)
+		{
+			_libraryManager = libraryManager;
+			_taskManager = taskManager;
+			_logger = logger;
+		}
+
+		/// <inheritdoc />
+		public TaskParameters GetParameters()
+		{
+			return new();
+		}
+
+		/// <inheritdoc />
+		public async Task Run(TaskParameters arguments, IProgress<float> progress, CancellationToken cancellationToken)
+		{
+			ICollection<Provider> providers = await _libraryManager.GetAll<Provider>();
+			ICollection<string> existings = (await _libraryManager.GetAll<Library>()).SelectMany(x => x.Paths).ToArray();
+			IEnumerable<Library> newLibraries = Directory.GetDirectories(Environment.GetEnvironmentVariable("LIBRARY_ROOT") ?? "/video")
+				.Where(x => !existings.Contains(x))
+				.Select(x => new Library
+				{
+					Slug = Utility.ToSlug(Path.GetFileName(x)),
+					Name = Path.GetFileName(x),
+					Paths = new string[] { x },
+					Providers = providers,
+				});
+
+			foreach (Library library in newLibraries)
+			{
+				await _libraryManager.Create(library);
+			}
+		}
+	}
+}

--- a/back/src/Kyoo.Core/Views/Admin/ConfigurationApi.cs
+++ b/back/src/Kyoo.Core/Views/Admin/ConfigurationApi.cs
@@ -16,11 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using System.Threading.Tasks;
 using Kyoo.Abstractions.Controllers;
 using Kyoo.Abstractions.Models.Attributes;
-using Kyoo.Abstractions.Models.Exceptions;
 using Kyoo.Abstractions.Models.Permissions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -68,14 +66,7 @@ namespace Kyoo.Core.Api
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public ActionResult<object> GetConfiguration(string slug)
 		{
-			try
-			{
-				return _manager.GetValue(slug);
-			}
-			catch (ItemNotFoundException)
-			{
-				return NotFound();
-			}
+			return _manager.GetValue(slug);
 		}
 
 		/// <summary>
@@ -95,19 +86,8 @@ namespace Kyoo.Core.Api
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public async Task<ActionResult<object>> EditConfiguration(string slug, [FromBody] object newValue)
 		{
-			try
-			{
-				await _manager.EditValue(slug, newValue);
-				return newValue;
-			}
-			catch (ItemNotFoundException)
-			{
-				return NotFound();
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(ex.Message);
-			}
+			await _manager.EditValue(slug, newValue);
+			return newValue;
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Admin/TaskApi.cs
+++ b/back/src/Kyoo.Core/Views/Admin/TaskApi.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using Kyoo.Abstractions.Controllers;
 using Kyoo.Abstractions.Models.Attributes;
-using Kyoo.Abstractions.Models.Exceptions;
 using Kyoo.Abstractions.Models.Permissions;
 using Kyoo.Abstractions.Models.Utils;
 using Microsoft.AspNetCore.Http;
@@ -90,19 +89,8 @@ namespace Kyoo.Core.Api
 		public IActionResult RunTask(string taskSlug,
 			[FromQuery] Dictionary<string, object> args)
 		{
-			try
-			{
-				_taskManager.StartTask(taskSlug, new Progress<float>(), args);
-				return Ok();
-			}
-			catch (ItemNotFoundException)
-			{
-				return NotFound();
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(new RequestError(ex.Message));
-			}
+			_taskManager.StartTask(taskSlug, new Progress<float>(), args);
+			return Ok();
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Helper/CrudApi.cs
+++ b/back/src/Kyoo.Core/Views/Helper/CrudApi.cs
@@ -120,7 +120,7 @@ namespace Kyoo.Core.Api
 				pagination
 			);
 
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>

--- a/back/src/Kyoo.Core/Views/Helper/CrudApi.cs
+++ b/back/src/Kyoo.Core/Views/Helper/CrudApi.cs
@@ -129,7 +129,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<T> resources = await Repository.GetAll(
 					ApiHelper.ParseWhere<T>(where),
-					new Sort<T>(sortBy),
+					Sort<T>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 

--- a/back/src/Kyoo.Core/Views/Helper/ResourceViewAttribute.cs
+++ b/back/src/Kyoo.Core/Views/Helper/ResourceViewAttribute.cs
@@ -44,9 +44,14 @@ namespace Kyoo.Core.Api
 		{
 			if (context.ActionArguments.TryGetValue("where", out object dic) && dic is Dictionary<string, string> where)
 			{
-				where.Remove("fields");
+				Dictionary<string, string> nWhere = new(where, StringComparer.InvariantCultureIgnoreCase);
+				nWhere.Remove("fields");
+				nWhere.Remove("afterID");
+				nWhere.Remove("limit");
+				nWhere.Remove("reverse");
 				foreach ((string key, _) in context.ActionArguments)
-					where.Remove(key);
+					nWhere.Remove(key);
+				context.ActionArguments["where"] = nWhere;
 			}
 
 			List<string> fields = context.HttpContext.Request.Query["fields"]

--- a/back/src/Kyoo.Core/Views/Metadata/GenreApi.cs
+++ b/back/src/Kyoo.Core/Views/Metadata/GenreApi.cs
@@ -88,7 +88,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Show> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Show, Genre>(x => x.Genres)),
-					new Sort<Show>(sortBy),
+					Sort<Show>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 

--- a/back/src/Kyoo.Core/Views/Metadata/GenreApi.cs
+++ b/back/src/Kyoo.Core/Views/Metadata/GenreApi.cs
@@ -89,7 +89,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Genre>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Metadata/StaffApi.cs
+++ b/back/src/Kyoo.Core/Views/Metadata/StaffApi.cs
@@ -95,7 +95,7 @@ namespace Kyoo.Core.Api
 				slug => _libraryManager.GetRolesFromPeople(slug, whereQuery, sort, pagination)
 			);
 
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Metadata/StaffApi.cs
+++ b/back/src/Kyoo.Core/Views/Metadata/StaffApi.cs
@@ -93,7 +93,7 @@ namespace Kyoo.Core.Api
 			try
 			{
 				Expression<Func<PeopleRole, bool>> whereQuery = ApiHelper.ParseWhere<PeopleRole>(where);
-				Sort<PeopleRole> sort = new(sortBy);
+				Sort<PeopleRole> sort = Sort<PeopleRole>.From(sortBy);
 				Pagination pagination = new(limit, afterID);
 
 				ICollection<PeopleRole> resources = await identifier.Match(

--- a/back/src/Kyoo.Core/Views/Metadata/StudioApi.cs
+++ b/back/src/Kyoo.Core/Views/Metadata/StudioApi.cs
@@ -90,7 +90,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Studio>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Metadata/StudioApi.cs
+++ b/back/src/Kyoo.Core/Views/Metadata/StudioApi.cs
@@ -88,7 +88,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Show> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.Matcher<Show>(x => x.StudioID, x => x.Studio.Slug)),
-					new Sort<Show>(sortBy),
+					Sort<Show>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 

--- a/back/src/Kyoo.Core/Views/Metadata/StudioApi.cs
+++ b/back/src/Kyoo.Core/Views/Metadata/StudioApi.cs
@@ -67,8 +67,7 @@ namespace Kyoo.Core.Api
 		/// <param name="identifier">The ID or slug of the <see cref="Studio"/>.</param>
 		/// <param name="sortBy">A key to sort shows by.</param>
 		/// <param name="where">An optional list of filters.</param>
-		/// <param name="limit">The number of shows to return.</param>
-		/// <param name="afterID">An optional show's ID to start the query from this specific item.</param>
+		/// <param name="pagination">The number of shows to return.</param>
 		/// <returns>A page of shows.</returns>
 		/// <response code="400">The filters or the sort parameters are invalid.</response>
 		/// <response code="404">No studio with the given ID or slug could be found.</response>
@@ -81,25 +80,17 @@ namespace Kyoo.Core.Api
 		public async Task<ActionResult<Page<Show>>> GetShows(Identifier identifier,
 			[FromQuery] string sortBy,
 			[FromQuery] Dictionary<string, string> where,
-			[FromQuery] int limit = 20,
-			[FromQuery] int? afterID = null)
+			[FromQuery] Pagination pagination)
 		{
-			try
-			{
-				ICollection<Show> resources = await _libraryManager.GetAll(
-					ApiHelper.ParseWhere(where, identifier.Matcher<Show>(x => x.StudioID, x => x.Studio.Slug)),
-					Sort<Show>.From(sortBy),
-					new Pagination(limit, afterID)
-				);
+			ICollection<Show> resources = await _libraryManager.GetAll(
+				ApiHelper.ParseWhere(where, identifier.Matcher<Show>(x => x.StudioID, x => x.Studio.Slug)),
+				Sort<Show>.From(sortBy),
+				pagination
+			);
 
-				if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Studio>()) == null)
-					return NotFound();
-				return Page(resources, limit);
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(new RequestError(ex.Message));
-			}
+			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Studio>()) == null)
+				return NotFound();
+			return Page(resources, pagination.Count);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/CollectionApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/CollectionApi.cs
@@ -93,7 +93,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Collection>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -128,7 +128,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Collection>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/CollectionApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/CollectionApi.cs
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -71,8 +70,7 @@ namespace Kyoo.Core.Api
 		/// <param name="identifier">The ID or slug of the <see cref="Collection"/>.</param>
 		/// <param name="sortBy">A key to sort shows by.</param>
 		/// <param name="where">An optional list of filters.</param>
-		/// <param name="limit">The number of shows to return.</param>
-		/// <param name="afterID">An optional show's ID to start the query from this specific item.</param>
+		/// <param name="pagination">The number of shows to return.</param>
 		/// <returns>A page of shows.</returns>
 		/// <response code="400">The filters or the sort parameters are invalid.</response>
 		/// <response code="404">No collection with the given ID could be found.</response>
@@ -85,25 +83,17 @@ namespace Kyoo.Core.Api
 		public async Task<ActionResult<Page<Show>>> GetShows(Identifier identifier,
 			[FromQuery] string sortBy,
 			[FromQuery] Dictionary<string, string> where,
-			[FromQuery] int limit = 30,
-			[FromQuery] int? afterID = null)
+			[FromQuery] Pagination pagination)
 		{
-			try
-			{
-				ICollection<Show> resources = await _libraryManager.GetAll(
-					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Show, Collection>(x => x.Collections)),
-					Sort<Show>.From(sortBy),
-					new Pagination(limit, afterID)
-				);
+			ICollection<Show> resources = await _libraryManager.GetAll(
+				ApiHelper.ParseWhere(where, identifier.IsContainedIn<Show, Collection>(x => x.Collections)),
+				Sort<Show>.From(sortBy),
+				pagination
+			);
 
-				if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Collection>()) == null)
-					return NotFound();
-				return Page(resources, limit);
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(new RequestError(ex.Message));
-			}
+			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Collection>()) == null)
+				return NotFound();
+			return Page(resources, pagination.Count);
 		}
 
 		/// <summary>
@@ -115,8 +105,7 @@ namespace Kyoo.Core.Api
 		/// <param name="identifier">The ID or slug of the <see cref="Collection"/>.</param>
 		/// <param name="sortBy">A key to sort libraries by.</param>
 		/// <param name="where">An optional list of filters.</param>
-		/// <param name="limit">The number of libraries to return.</param>
-		/// <param name="afterID">An optional library's ID to start the query from this specific item.</param>
+		/// <param name="pagination">The number of libraries to return.</param>
 		/// <returns>A page of libraries.</returns>
 		/// <response code="400">The filters or the sort parameters are invalid.</response>
 		/// <response code="404">No collection with the given ID or slug could be found.</response>
@@ -129,25 +118,17 @@ namespace Kyoo.Core.Api
 		public async Task<ActionResult<Page<Library>>> GetLibraries(Identifier identifier,
 			[FromQuery] string sortBy,
 			[FromQuery] Dictionary<string, string> where,
-			[FromQuery] int limit = 30,
-			[FromQuery] int? afterID = null)
+			[FromQuery] Pagination pagination)
 		{
-			try
-			{
-				ICollection<Library> resources = await _libraryManager.GetAll(
-					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Library, Collection>(x => x.Collections)),
-					Sort<Library>.From(sortBy),
-					new Pagination(limit, afterID)
-				);
+			ICollection<Library> resources = await _libraryManager.GetAll(
+				ApiHelper.ParseWhere(where, identifier.IsContainedIn<Library, Collection>(x => x.Collections)),
+				Sort<Library>.From(sortBy),
+				pagination
+			);
 
-				if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Collection>()) == null)
-					return NotFound();
-				return Page(resources, limit);
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(new RequestError(ex.Message));
-			}
+			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Collection>()) == null)
+				return NotFound();
+			return Page(resources, pagination.Count);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/CollectionApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/CollectionApi.cs
@@ -92,7 +92,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Show> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Show, Collection>(x => x.Collections)),
-					new Sort<Show>(sortBy),
+					Sort<Show>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 
@@ -136,7 +136,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Library> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Library, Collection>(x => x.Collections)),
-					new Sort<Library>(sortBy),
+					Sort<Library>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 

--- a/back/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
@@ -158,7 +158,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Episode>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
@@ -160,7 +160,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Track> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.Matcher<Track>(x => x.EpisodeID, x => x.Episode.Slug)),
-					new Sort<Track>(sortBy),
+					Sort<Track>.From(sortBy),
 					new Pagination(limit, afterID));
 
 				if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Episode>()) == null)

--- a/back/src/Kyoo.Core/Views/Resources/LibraryApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/LibraryApi.cs
@@ -91,7 +91,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Show> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Show, Library>(x => x.Libraries)),
-					new Sort<Show>(sortBy),
+					Sort<Show>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 
@@ -135,7 +135,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Collection> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Collection, Library>(x => x.Libraries)),
-					new Sort<Collection>(sortBy),
+					Sort<Collection>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 
@@ -181,7 +181,7 @@ namespace Kyoo.Core.Api
 			try
 			{
 				Expression<Func<LibraryItem, bool>> whereQuery = ApiHelper.ParseWhere<LibraryItem>(where);
-				Sort<LibraryItem> sort = new(sortBy);
+				Sort<LibraryItem> sort = Sort<LibraryItem>.From(sortBy);
 				Pagination pagination = new(limit, afterID);
 
 				ICollection<LibraryItem> resources = await identifier.Match(

--- a/back/src/Kyoo.Core/Views/Resources/LibraryApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/LibraryApi.cs
@@ -92,7 +92,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Library>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -127,7 +127,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Library>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -165,7 +165,7 @@ namespace Kyoo.Core.Api
 				slug => _libraryManager.GetItemsFromLibrary(slug, whereQuery, sort, pagination)
 			);
 
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
@@ -89,7 +89,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<LibraryItem> resources = await _libraryItems.GetAll(
 					ApiHelper.ParseWhere<LibraryItem>(where),
-					new Sort<LibraryItem>(sortBy),
+					Sort<LibraryItem>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 

--- a/back/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
@@ -69,8 +69,7 @@ namespace Kyoo.Core.Api
 		/// </remarks>
 		/// <param name="sortBy">A key to sort items by.</param>
 		/// <param name="where">An optional list of filters.</param>
-		/// <param name="limit">The number of items to return.</param>
-		/// <param name="afterID">An optional item's ID to start the query from this specific item.</param>
+		/// <param name="pagination">The number of items to return.</param>
 		/// <returns>A page of items.</returns>
 		/// <response code="400">The filters or the sort parameters are invalid.</response>
 		/// <response code="404">No library with the given ID or slug could be found.</response>
@@ -82,23 +81,15 @@ namespace Kyoo.Core.Api
 		public async Task<ActionResult<Page<LibraryItem>>> GetAll(
 			[FromQuery] string sortBy,
 			[FromQuery] Dictionary<string, string> where,
-			[FromQuery] int limit = 50,
-			[FromQuery] int? afterID = null)
+			[FromQuery] Pagination pagination)
 		{
-			try
-			{
-				ICollection<LibraryItem> resources = await _libraryItems.GetAll(
-					ApiHelper.ParseWhere<LibraryItem>(where),
-					Sort<LibraryItem>.From(sortBy),
-					new Pagination(limit, afterID)
-				);
+			ICollection<LibraryItem> resources = await _libraryItems.GetAll(
+				ApiHelper.ParseWhere<LibraryItem>(where),
+				Sort<LibraryItem>.From(sortBy),
+				pagination
+			);
 
-				return Page(resources, limit);
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(new RequestError(ex.Message));
-			}
+			return Page(resources, pagination.Count);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/LibraryItemApi.cs
@@ -89,7 +89,7 @@ namespace Kyoo.Core.Api
 				pagination
 			);
 
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/SeasonApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/SeasonApi.cs
@@ -93,7 +93,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Season>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>

--- a/back/src/Kyoo.Core/Views/Resources/SeasonApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/SeasonApi.cs
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -71,8 +70,7 @@ namespace Kyoo.Core.Api
 		/// <param name="identifier">The ID or slug of the <see cref="Season"/>.</param>
 		/// <param name="sortBy">A key to sort episodes by.</param>
 		/// <param name="where">An optional list of filters.</param>
-		/// <param name="limit">The number of episodes to return.</param>
-		/// <param name="afterID">An optional episode's ID to start the query from this specific item.</param>
+		/// <param name="pagination">The number of episodes to return.</param>
 		/// <returns>A page of episodes.</returns>
 		/// <response code="400">The filters or the sort parameters are invalid.</response>
 		/// <response code="404">No season with the given ID or slug could be found.</response>
@@ -85,24 +83,17 @@ namespace Kyoo.Core.Api
 		public async Task<ActionResult<Page<Episode>>> GetEpisode(Identifier identifier,
 			[FromQuery] string sortBy,
 			[FromQuery] Dictionary<string, string> where,
-			[FromQuery] int limit = 30,
-			[FromQuery] int? afterID = null)
+			[FromQuery] Pagination pagination)
 		{
-			try
-			{
-				ICollection<Episode> resources = await _libraryManager.GetAll(
-					ApiHelper.ParseWhere(where, identifier.Matcher<Episode>(x => x.SeasonID, x => x.Season.Slug)),
-					Sort<Episode>.From(sortBy),
-					new Pagination(limit, afterID));
+			ICollection<Episode> resources = await _libraryManager.GetAll(
+				ApiHelper.ParseWhere(where, identifier.Matcher<Episode>(x => x.SeasonID, x => x.Season.Slug)),
+				Sort<Episode>.From(sortBy),
+				pagination
+			);
 
-				if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Season>()) == null)
-					return NotFound();
-				return Page(resources, limit);
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(new RequestError(ex.Message));
-			}
+			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Season>()) == null)
+				return NotFound();
+			return Page(resources, pagination.Count);
 		}
 
 		/// <summary>

--- a/back/src/Kyoo.Core/Views/Resources/SeasonApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/SeasonApi.cs
@@ -92,7 +92,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Episode> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.Matcher<Episode>(x => x.SeasonID, x => x.Season.Slug)),
-					new Sort<Episode>(sortBy),
+					Sort<Episode>.From(sortBy),
 					new Pagination(limit, afterID));
 
 				if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Season>()) == null)

--- a/back/src/Kyoo.Core/Views/Resources/ShowApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/ShowApi.cs
@@ -97,7 +97,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Show>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -132,7 +132,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Show>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -166,7 +166,7 @@ namespace Kyoo.Core.Api
 				id => _libraryManager.GetPeopleFromShow(id, whereQuery, sort, pagination),
 				slug => _libraryManager.GetPeopleFromShow(slug, whereQuery, sort, pagination)
 			);
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -201,7 +201,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Show>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -255,7 +255,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Show>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 
 		/// <summary>
@@ -290,7 +290,7 @@ namespace Kyoo.Core.Api
 
 			if (!resources.Any() && await _libraryManager.GetOrDefault(identifier.IsSame<Show>()) == null)
 				return NotFound();
-			return Page(resources, pagination.Count);
+			return Page(resources, pagination.Limit);
 		}
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/ShowApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/ShowApi.cs
@@ -96,7 +96,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Season> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.Matcher<Season>(x => x.ShowID, x => x.Show.Slug)),
-					new Sort<Season>(sortBy),
+					Sort<Season>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 
@@ -140,7 +140,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Episode> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.Matcher<Episode>(x => x.ShowID, x => x.Show.Slug)),
-					new Sort<Episode>(sortBy),
+					Sort<Episode>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 
@@ -183,7 +183,7 @@ namespace Kyoo.Core.Api
 			try
 			{
 				Expression<Func<PeopleRole, bool>> whereQuery = ApiHelper.ParseWhere<PeopleRole>(where);
-				Sort<PeopleRole> sort = new(sortBy);
+				Sort<PeopleRole> sort = Sort<PeopleRole>.From(sortBy);
 				Pagination pagination = new(limit, afterID);
 
 				ICollection<PeopleRole> resources = await identifier.Match(
@@ -232,7 +232,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Genre> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Genre, Show>(x => x.Shows)),
-					new Sort<Genre>(sortBy),
+					Sort<Genre>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 
@@ -298,7 +298,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Library> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Library, Show>(x => x.Shows)),
-					new Sort<Library>(sortBy),
+					Sort<Library>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 
@@ -342,7 +342,7 @@ namespace Kyoo.Core.Api
 			{
 				ICollection<Collection> resources = await _libraryManager.GetAll(
 					ApiHelper.ParseWhere(where, identifier.IsContainedIn<Collection, Show>(x => x.Shows)),
-					new Sort<Collection>(sortBy),
+					Sort<Collection>.From(sortBy),
 					new Pagination(limit, afterID)
 				);
 

--- a/back/src/Kyoo.Core/Views/Watch/TrackApi.cs
+++ b/back/src/Kyoo.Core/Views/Watch/TrackApi.cs
@@ -72,10 +72,7 @@ namespace Kyoo.Core.Api
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		public async Task<ActionResult<Episode>> GetEpisode(Identifier identifier)
 		{
-			Episode ret = await _libraryManager.GetOrDefault(identifier.IsContainedIn<Episode, Track>(x => x.Tracks));
-			if (ret == null)
-				return NotFound();
-			return ret;
+			return await _libraryManager.Get(identifier.IsContainedIn<Episode, Track>(x => x.Tracks));
 		}
 	}
 }

--- a/back/src/Kyoo.Database/DatabaseContext.cs
+++ b/back/src/Kyoo.Database/DatabaseContext.cs
@@ -424,28 +424,6 @@ namespace Kyoo.Database
 		/// <summary>
 		/// Save changes that are applied to this context.
 		/// </summary>
-		/// <param name="duplicateMessage">The message that will have the <see cref="DuplicatedItemException"/>
-		/// (if a duplicate is found).</param>
-		/// <exception cref="DuplicatedItemException">A duplicated item has been found.</exception>
-		/// <returns>The number of state entries written to the database.</returns>
-		public int SaveChanges(string duplicateMessage)
-		{
-			try
-			{
-				return base.SaveChanges();
-			}
-			catch (DbUpdateException ex)
-			{
-				DiscardChanges();
-				if (IsDuplicateException(ex))
-					throw new DuplicatedItemException(duplicateMessage);
-				throw;
-			}
-		}
-
-		/// <summary>
-		/// Save changes that are applied to this context.
-		/// </summary>
 		/// <param name="acceptAllChangesOnSuccess">Indicates whether AcceptAllChanges() is called after the changes
 		/// have been sent successfully to the database.</param>
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete</param>
@@ -491,12 +469,13 @@ namespace Kyoo.Database
 		/// <summary>
 		/// Save changes that are applied to this context.
 		/// </summary>
-		/// <param name="duplicateMessage">The message that will have the <see cref="DuplicatedItemException"/>
-		/// (if a duplicate is found).</param>
+		/// <param name="getExisting">How to retrieve the conflicting item.</param>
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete</param>
 		/// <exception cref="DuplicatedItemException">A duplicated item has been found.</exception>
+		/// <typeparam name="T">The type of the potential duplicate (this is unused).</typeparam>
 		/// <returns>The number of state entries written to the database.</returns>
-		public async Task<int> SaveChangesAsync(string duplicateMessage,
+		public async Task<int> SaveChangesAsync<T>(
+			Func<Task<T>> getExisting,
 			CancellationToken cancellationToken = default)
 		{
 			try
@@ -507,7 +486,7 @@ namespace Kyoo.Database
 			{
 				DiscardChanges();
 				if (IsDuplicateException(ex))
-					throw new DuplicatedItemException(duplicateMessage);
+					throw new DuplicatedItemException(await getExisting());
 				throw;
 			}
 		}

--- a/back/tests/Kyoo.Tests/Identifier/IdentifierTests.cs
+++ b/back/tests/Kyoo.Tests/Identifier/IdentifierTests.cs
@@ -57,7 +57,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task EpisodeIdentification()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo/Library/"}}
 			});
@@ -77,7 +77,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task EpisodeIdentificationWithoutLibraryTrailingSlash()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo/Library"}}
 			});
@@ -97,7 +97,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task EpisodeIdentificationMultiplePaths()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo", "/kyoo/Library/"}}
 			});
@@ -117,7 +117,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task AbsoluteEpisodeIdentification()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo", "/kyoo/Library/"}}
 			});
@@ -137,7 +137,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task MovieEpisodeIdentification()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo", "/kyoo/Library/"}}
 			});
@@ -158,7 +158,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task InvalidEpisodeIdentification()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo", "/kyoo/Library/"}}
 			});
@@ -168,7 +168,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task SubtitleIdentification()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo", "/kyoo/Library/"}}
 			});
@@ -184,7 +184,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task SubtitleIdentificationUnknownCodec()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo", "/kyoo/Library/"}}
 			});
@@ -200,7 +200,7 @@ namespace Kyoo.Tests.Identifier
 		[Fact]
 		public async Task InvalidSubtitleIdentification()
 		{
-			_manager.Setup(x => x.GetAll(null, new Sort<Library>(), default)).ReturnsAsync(new[]
+			_manager.Setup(x => x.GetAll<Library>(null, default, default)).ReturnsAsync(new[]
 			{
 				new Library {Paths = new [] {"/kyoo", "/kyoo/Library/"}}
 			});

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   back:
-    build: 
+    build:
       context: ./back
       dockerfile: Dockerfile.dev
     ports:
@@ -16,6 +16,7 @@ services:
       - DATABASE__CONFIGURATIONS__POSTGRES__PASSWORD=${POSTGRES_PASSWORD}
       - TVDB__APIKEY=${TVDB__APIKEY}
       - THEMOVIEDB__APIKEY=${THEMOVIEDB__APIKEY}
+      - LIBRARY_ROOT=/video
     depends_on:
       - postgres
     volumes:
@@ -24,7 +25,7 @@ services:
       - kyoo:/var/lib/kyoo
       - ./video:/video
   front:
-    build: 
+    build:
       context: ./front
       dockerfile: Dockerfile.dev
     volumes:
@@ -67,4 +68,3 @@ services:
 volumes:
   kyoo:
   db:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - DATABASE__CONFIGURATIONS__POSTGRES__DATABASE=${POSTGRES_DB}
       - TVDB__APIKEY=${TVDB__APIKEY}
       - THEMOVIEDB__APIKEY=${THEMOVIEDB__APIKEY}
+      - LIBRARY_ROOT=/video
     depends_on:
       - postgres
     volumes:
@@ -52,4 +53,3 @@ services:
 volumes:
   kyoo:
   db:
-

--- a/front/packages/primitives/src/menu.web.tsx
+++ b/front/packages/primitives/src/menu.web.tsx
@@ -79,6 +79,7 @@ const Menu = <AsProps extends { onPress: PressableProps["onPress"] }>({
 									borderRadius: "8px",
 									boxShadow:
 										"0px 10px 38px -10px rgba(22, 23, 24, 0.35), 0px 10px 20px -15px rgba(22, 23, 24, 0.2)",
+									zIndex: 2,
 								})}
 							>
 								{children}

--- a/front/packages/ui/src/details/header.tsx
+++ b/front/packages/ui/src/details/header.tsx
@@ -190,21 +190,24 @@ const TitleLine = ({
 					}),
 				])}
 			>
-				<P
-					{...css({
-						color: (theme: Theme) => theme.user.paragraph,
-						display: "flex",
-					})}
-				>
-					{t("show.studio")}:{" "}
-					{isLoading ? (
-						<Skeleton {...css({ width: rem(5) })} />
-					) : (
-						<A href={`/studio/${studio!.slug}`} {...css({ color: (theme) => theme.user.link })}>
-							{studio!.name}
-						</A>
-					)}
-				</P>
+				{isLoading ||
+					(studio && (
+						<P
+							{...css({
+								color: (theme: Theme) => theme.user.paragraph,
+								display: "flex",
+							})}
+						>
+							{t("show.studio")}:{" "}
+							{isLoading ? (
+								<Skeleton {...css({ width: rem(5) })} />
+							) : (
+								<A href={`/studio/${studio.slug}`} {...css({ color: (theme) => theme.user.link })}>
+									{studio.name}
+								</A>
+							)}
+						</P>
+					))}
 			</View>
 		</Container>
 	);

--- a/front/packages/ui/src/navbar/index.tsx
+++ b/front/packages/ui/src/navbar/index.tsx
@@ -191,6 +191,7 @@ export const Navbar = (props: Stylable) => {
 					shadowOpacity: 0.3,
 					shadowRadius: 4.65,
 					elevation: 8,
+					zIndex: 1,
 				},
 				props,
 			)}


### PR DESCRIPTION
 - Automatically create libraries
 - Fix front's navbar zIndex
 - Items can now be sorted by multiple keys (example /api/episodes?sortBy=absoluteNumber:asc,seasonNumber:desc,episodeNumber,default)
 - Fix AfterID issues
 - Add reverse & previous in the page
 - Cleanup exception handling on the API