### PR TITLE
Add season headers and quick jump in the show's detail page.

### DIFF
--- a/front/packages/models/src/query.tsx
+++ b/front/packages/models/src/query.tsx
@@ -155,7 +155,7 @@ export type QueryIdentifier<T = unknown, Ret = T> = {
 	parser: z.ZodType<T, z.ZodTypeDef, any>;
 	path: (string | undefined)[];
 	params?: { [query: string]: boolean | number | string | string[] | undefined };
-	infinite?: boolean | { value: true; map?: (x: T[]) => Ret[] };
+	infinite?: boolean | { value: true; map?: (x: any[]) => Ret[] };
 	/**
 	 * A custom get next function if the infinite query is not a page.
 	 */
@@ -163,7 +163,7 @@ export type QueryIdentifier<T = unknown, Ret = T> = {
 };
 
 export type QueryPage<Props = {}> = ComponentType<Props> & {
-	getFetchUrls?: (route: { [key: string]: string }) => QueryIdentifier[];
+	getFetchUrls?: (route: { [key: string]: string }) => QueryIdentifier<any>[];
 	getLayout?:
 		| QueryPage<{ page: ReactElement }>
 		| { Layout: QueryPage<{ page: ReactElement }>; props: object };

--- a/front/packages/primitives/src/divider.tsx
+++ b/front/packages/primitives/src/divider.tsx
@@ -40,14 +40,14 @@ export const HR = ({
 					orientation === "vertical" && {
 						width: px(1),
 						height: "auto",
-						marginVertical: ts(1),
-						marginHorizontal: ts(2),
+						marginY: ts(1),
+						marginX: ts(2),
 					},
 					orientation === "horizontal" && {
 						height: px(1),
 						width: "auto",
-						marginHorizontal: ts(1),
-						marginVertical: ts(2),
+						marginX: ts(1),
+						marginY: ts(2),
 					},
 				],
 				props,

--- a/front/packages/primitives/src/icons.tsx
+++ b/front/packages/primitives/src/icons.tsx
@@ -83,6 +83,7 @@ export const IconButton = forwardRef(function IconButton<AsProps = PressableProp
 			focusRipple
 			{...(css(
 				{
+					alignSelf: "center",
 					p: ts(1),
 					m: px(2),
 					borderRadius: 9999,

--- a/front/packages/primitives/src/image/blurhash.tsx
+++ b/front/packages/primitives/src/image/blurhash.tsx
@@ -1,0 +1,43 @@
+/*
+ * Kyoo - A portable and vast media library solution.
+ * Copyright (c) Kyoo.
+ *
+ * See AUTHORS.md and LICENSE file in the project root for full license information.
+ *
+ * Kyoo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Kyoo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { ReactElement } from "react";
+import { View } from "react-native";
+import { Blurhash } from "react-native-blurhash";
+import { Stylable, useYoshiki } from "yoshiki/native";
+
+export const BlurhashContainer = ({
+	blurhash,
+	children,
+	...props
+}: { blurhash: string; children?: ReactElement | ReactElement[] } & Stylable) => {
+	const { css } = useYoshiki();
+
+	return (
+		<View {...props}>
+			<Blurhash
+				blurhash={blurhash}
+				resizeMode="cover"
+				{...css({ position: "absolute", top: 0, bottom: 0, left: 0, right: 0 })}
+			/>
+			{children}
+		</View>
+	);
+};

--- a/front/packages/primitives/src/image/index.tsx
+++ b/front/packages/primitives/src/image/index.tsx
@@ -18,14 +18,15 @@
  * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { ImageProps, ImageStyle, Platform, View, ViewProps, ViewStyle } from "react-native";
+import { ImageStyle, View, ViewProps, ViewStyle } from "react-native";
 import { Props, YoshikiEnhanced } from "./base-image";
 import { Image } from "./image";
-import { ComponentType, ReactNode, useState } from "react";
+import { ComponentType, ReactNode } from "react";
 import { LinearGradient, LinearGradientProps } from "expo-linear-gradient";
 import { ContrastArea, alpha } from "../themes";
 import { percent } from "yoshiki/native";
 
+export { BlurhashContainer } from "./blurhash";
 export { type Props as ImageProps, Image };
 
 export const Poster = ({

--- a/front/packages/ui/src/details/season.tsx
+++ b/front/packages/ui/src/details/season.tsx
@@ -123,7 +123,7 @@ export const EpisodeList = <Props,>({
 			headerProps={headerProps}
 		>
 			{(item) => {
-				const sea = item ? seasons?.find((x) => x.seasonNumber === item.seasonNumber) : null;
+				const sea = item?.firstOfSeason ? seasons?.find((x) => x.seasonNumber === item.seasonNumber) : null;
 				return (
 					<>
 						{item.firstOfSeason && (

--- a/front/packages/ui/src/details/show.tsx
+++ b/front/packages/ui/src/details/show.tsx
@@ -22,7 +22,7 @@ import { QueryIdentifier, QueryPage, Show, ShowP } from "@kyoo/models";
 import { Platform, View, ViewProps } from "react-native";
 import { percent, useYoshiki } from "yoshiki/native";
 import { DefaultLayout } from "../layout";
-import { EpisodeList } from "./season";
+import { EpisodeList, SeasonHeader } from "./season";
 import { Header } from "./header";
 import Svg, { Path, SvgProps } from "react-native-svg";
 import { Container } from "@kyoo/primitives";
@@ -75,7 +75,6 @@ const ShowHeader = forwardRef<View, ViewProps & { slug: string }>(function ShowH
 				fill={theme.variant.background}
 				{...css({ flexShrink: 0, flexGrow: 1, display: "flex" })}
 			/>
-			{/* <SeasonTab slug={slug} season={season} /> */}
 			<View {...css({ bg: theme.variant.background })}>
 				<Container>{children}</Container>
 			</View>
@@ -104,6 +103,7 @@ ShowDetails.getFetchUrls = ({ slug, season }) => [
 	query(slug),
 	// ShowStaff.query(slug),
 	EpisodeList.query(slug, season),
+	SeasonHeader.query(slug),
 ];
 
 ShowDetails.getLayout = { Layout: DefaultLayout, props: { transparent: true } };

--- a/front/packages/ui/src/fetch-infinite.tsx
+++ b/front/packages/ui/src/fetch-infinite.tsx
@@ -24,7 +24,7 @@ import { FlashList } from "@shopify/flash-list";
 import { ComponentType, isValidElement, ReactElement, useRef } from "react";
 import { EmptyView, ErrorView, Layout, WithLoading } from "./fetch";
 
-export const InfiniteFetch = <Data, Props>({
+export const InfiniteFetch = <Data, Props, _>({
 	query,
 	placeholderCount = 15,
 	incremental = false,
@@ -37,7 +37,7 @@ export const InfiniteFetch = <Data, Props>({
 	headerProps,
 	...props
 }: {
-	query: QueryIdentifier<Data>;
+	query: QueryIdentifier<_, Data>;
 	placeholderCount?: number;
 	layout: Layout;
 	horizontal?: boolean;
@@ -49,7 +49,7 @@ export const InfiniteFetch = <Data, Props>({
 	incremental?: boolean;
 	divider?: boolean | ComponentType;
 	Header?: ComponentType<Props & { children: JSX.Element }> | ReactElement;
-	headerProps?: Props
+	headerProps?: Props;
 }): JSX.Element | null => {
 	if (!query.infinite) console.warn("A non infinite query was passed to an InfiniteFetch.");
 
@@ -69,15 +69,14 @@ export const InfiniteFetch = <Data, Props>({
 		return <EmptyView message={empty} />;
 	}
 
-	if (incremental)
-		items ??= oldItems.current;
+	if (incremental) items ??= oldItems.current;
 	const count = items ? numColumns - (items.length % numColumns) : placeholderCount;
 	const placeholders = [...Array(count === 0 ? numColumns : count)].map(
-		(_, i) => ({ id: `gen${i}`, isLoading: true } as Data),
+		(_, i) => ({ id: `gen${i}`, isLoading: true }) as Data,
 	);
 
 	// @ts-ignore
-	if (headerProps && !isValidElement(Header)) Header = <Header {...headerProps} />
+	if (headerProps && !isValidElement(Header)) Header = <Header {...headerProps} />;
 	return (
 		<FlashList
 			renderItem={({ item, index }) => children({ isLoading: false, ...item } as any, index)}

--- a/front/packages/ui/src/fetch-infinite.web.tsx
+++ b/front/packages/ui/src/fetch-infinite.web.tsx
@@ -66,7 +66,8 @@ const InfiniteScroll = <Props,>({
 					{
 						display: "flex",
 						alignItems: "flex-start",
-						overflow: "auto",
+						overflowX: "hidden",
+						overflowY: "auto",
 					},
 					layout == "vertical" && {
 						flexDirection: "column",
@@ -101,7 +102,7 @@ const InfiniteScroll = <Props,>({
 	);
 };
 
-export const InfiniteFetch = <Data,>({
+export const InfiniteFetch = <Data, _>({
 	query,
 	incremental = false,
 	placeholderCount = 15,
@@ -113,7 +114,7 @@ export const InfiniteFetch = <Data,>({
 	Header,
 	...props
 }: {
-	query: QueryIdentifier<Data>;
+	query: QueryIdentifier<_, Data>;
 	incremental?: boolean;
 	placeholderCount?: number;
 	layout: Layout;

--- a/front/translations/en.json
+++ b/front/translations/en.json
@@ -10,7 +10,8 @@
 		"noOverview": "No overview available",
 		"episode-none": "There is no episodes in this season",
 		"episodeNoMetadata": "No metadata available",
-		"tags": "Tags"
+		"tags": "Tags",
+		"jumpToSeason": "Jump to season"
 	},
 	"browse": {
 		"sortby": "Sort by {{key}}",

--- a/front/translations/fr.json
+++ b/front/translations/fr.json
@@ -10,7 +10,8 @@
 		"noOverview": "Aucune description disponible",
 		"episode-none": "Il n'y a pas d'épisodes dans cette saison",
 		"episodeNoMetadata": "Aucune metadonnée disponible",
-		"tags": "Tags"
+		"tags": "Tags",
+		"jumpToSeason": "Aller sur une saison"
 	},
 	"browse": {
 		"sortby": "Trier par {{key}}",


### PR DESCRIPTION
To-do: add headers for bulk of episodes (like every 100 episodes) for series where there are huge seasons, and you don't want to scroll endlessly to reach your episode. Check the [feat/season-bulk](https://github.com/zoriya/kyoo/tree/feat/season-bulk) and koenbeuk/EntityFrameworkCore.Projectables#84 for progress.