### PR TITLE
Front: Fix chip text color on hover

### DIFF
--- a/front/packages/ui/src/details/header.tsx
+++ b/front/packages/ui/src/details/header.tsx
@@ -472,7 +472,7 @@ export const Header = ({
 									color: (theme: Theme) => theme.contrast,
 									fover: {
 										self: {
-											color: (theme: Theme) => theme.contrast,
+											color: (theme: Theme) => theme.alternate.contrast,
 											bg: (theme: Theme) => theme.accent,
 										},
 									},


### PR DESCRIPTION
This PR makes the color of chip text (on hover) consistent with the other chip styles

(On the screenshots below, the `Themoviedatabase` chip is hovered)
Before: 
<img width="423" alt="Screenshot 2023-12-08 at 10 06 34" src="https://github.com/zoriya/Kyoo/assets/60505370/0d85ba10-fff8-4438-a438-5a467a1236ad">
<img width="423" alt="Screenshot 2023-12-08 at 10 06 11" src="https://github.com/zoriya/Kyoo/assets/60505370/7a6176fd-24a5-4cda-8bdb-a4d3652deebb">

After:
<img width="423" alt="Screenshot 2023-12-08 at 10 13 55" src="https://github.com/zoriya/Kyoo/assets/60505370/d20e6f57-05fa-4913-a033-84f542829f27">
<img width="423" alt="Screenshot 2023-12-08 at 10 14 06" src="https://github.com/zoriya/Kyoo/assets/60505370/e01e9126-6ad9-4dc1-82d5-58306d5713e6">
