### PR TITLE
Fix episodes/movies where the duration is unknown

### DIFF
--- a/back/src/Kyoo.Abstractions/Controllers/IWatchStatusRepository.cs
+++ b/back/src/Kyoo.Abstractions/Controllers/IWatchStatusRepository.cs
@@ -48,7 +48,8 @@ public interface IWatchStatusRepository
 		Guid movieId,
 		Guid userId,
 		WatchStatus status,
-		int? watchedTime
+		int? watchedTime,
+		int? percent
 	);
 
 	Task DeleteMovieStatus(Guid movieId, Guid userId);
@@ -67,7 +68,8 @@ public interface IWatchStatusRepository
 		Guid episodeId,
 		Guid userId,
 		WatchStatus status,
-		int? watchedTime
+		int? watchedTime,
+		int? percent
 	);
 
 	Task DeleteEpisodeStatus(Guid episodeId, Guid userId);

--- a/back/src/Kyoo.Abstractions/Models/Resources/Episode.cs
+++ b/back/src/Kyoo.Abstractions/Models/Resources/Episode.cs
@@ -152,7 +152,7 @@ namespace Kyoo.Abstractions.Models
 		/// <summary>
 		/// How long is this episode? (in minutes)
 		/// </summary>
-		public int Runtime { get; set; }
+		public int? Runtime { get; set; }
 
 		/// <summary>
 		/// The release date of this episode. It can be null if unknown.

--- a/back/src/Kyoo.Abstractions/Models/Resources/Movie.cs
+++ b/back/src/Kyoo.Abstractions/Models/Resources/Movie.cs
@@ -99,7 +99,7 @@ namespace Kyoo.Abstractions.Models
 		/// <summary>
 		/// How long is this movie? (in minutes)
 		/// </summary>
-		public int Runtime { get; set; }
+		public int? Runtime { get; set; }
 
 		/// <summary>
 		/// The date this movie aired.

--- a/back/src/Kyoo.Core/Controllers/Repositories/WatchStatusRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/Repositories/WatchStatusRepository.cs
@@ -236,14 +236,14 @@ public class WatchStatusRepository : IWatchStatusRepository
 		Guid movieId,
 		Guid userId,
 		WatchStatus status,
-		int? watchedTime
+		int? watchedTime,
+		int? percent
 	)
 	{
 		Movie movie = await _movies.Get(movieId);
-		int? percent =
-			watchedTime != null && movie.Runtime > 0
-				? (int)Math.Round(watchedTime.Value / (movie.Runtime * 60f) * 100f)
-				: null;
+
+		if (percent == null && watchedTime != null && movie.Runtime > 0)
+			percent = (int)Math.Round(watchedTime.Value / (movie.Runtime.Value * 60f) * 100f);
 
 		if (percent < MinWatchPercent)
 			return null;
@@ -257,6 +257,12 @@ public class WatchStatusRepository : IWatchStatusRepository
 		if (watchedTime.HasValue && status != WatchStatus.Watching)
 			throw new ValidationException(
 				"Can't have a watched time if the status is not watching."
+			);
+
+		if (watchedTime.HasValue != percent.HasValue)
+			throw new ValidationException(
+				"Can't specify watched time without specifing percent (or vise-versa)."
+					+ "Percent could not be guessed since duration is unknown."
 			);
 
 		MovieWatchStatus ret =
@@ -463,14 +469,14 @@ public class WatchStatusRepository : IWatchStatusRepository
 		Guid episodeId,
 		Guid userId,
 		WatchStatus status,
-		int? watchedTime
+		int? watchedTime,
+		int? percent
 	)
 	{
 		Episode episode = await _database.Episodes.FirstAsync(x => x.Id == episodeId);
-		int? percent =
-			watchedTime != null && episode.Runtime > 0
-				? (int)Math.Round(watchedTime.Value / (episode.Runtime * 60f) * 100f)
-				: null;
+
+		if (percent == null && watchedTime != null && episode.Runtime > 0)
+			percent = (int)Math.Round(watchedTime.Value / (episode.Runtime.Value * 60f) * 100f);
 
 		if (percent < MinWatchPercent)
 			return null;
@@ -484,6 +490,12 @@ public class WatchStatusRepository : IWatchStatusRepository
 		if (watchedTime.HasValue && status != WatchStatus.Watching)
 			throw new ValidationException(
 				"Can't have a watched time if the status is not watching."
+			);
+
+		if (watchedTime.HasValue != percent.HasValue)
+			throw new ValidationException(
+				"Can't specify watched time without specifing percent (or vise-versa)."
+					+ "Percent could not be guessed since duration is unknown."
 			);
 
 		EpisodeWatchStatus ret =

--- a/back/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/EpisodeApi.cs
@@ -147,7 +147,8 @@ namespace Kyoo.Core.Api
 		/// </remarks>
 		/// <param name="identifier">The ID or slug of the <see cref="Episode"/>.</param>
 		/// <param name="status">The new watch status.</param>
-		/// <param name="watchedTime">Where the user stopped watching.</param>
+		/// <param name="watchedTime">Where the user stopped watching (in seconds).</param>
+		/// <param name="percent">Where the user stopped watching (in percent).</param>
 		/// <returns>The newly set status.</returns>
 		/// <response code="200">The status has been set</response>
 		/// <response code="204">The status was not considered impactfull enough to be saved (less then 5% of watched for example).</response>
@@ -161,7 +162,8 @@ namespace Kyoo.Core.Api
 		public async Task<EpisodeWatchStatus?> SetWatchStatus(
 			Identifier identifier,
 			WatchStatus status,
-			int? watchedTime
+			int? watchedTime,
+			int? percent
 		)
 		{
 			Guid id = await identifier.Match(
@@ -170,7 +172,7 @@ namespace Kyoo.Core.Api
 			);
 			return await _libraryManager
 				.WatchStatus
-				.SetEpisodeStatus(id, User.GetIdOrThrow(), status, watchedTime);
+				.SetEpisodeStatus(id, User.GetIdOrThrow(), status, watchedTime, percent);
 		}
 
 		/// <summary>

--- a/back/src/Kyoo.Core/Views/Resources/MovieApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/MovieApi.cs
@@ -196,6 +196,7 @@ namespace Kyoo.Core.Api
 		/// <param name="identifier">The ID or slug of the <see cref="Movie"/>.</param>
 		/// <param name="status">The new watch status.</param>
 		/// <param name="watchedTime">Where the user stopped watching.</param>
+		/// <param name="percent">Where the user stopped watching (in percent).</param>
 		/// <returns>The newly set status.</returns>
 		/// <response code="200">The status has been set</response>
 		/// <response code="204">The status was not considered impactfull enough to be saved (less then 5% of watched for example).</response>
@@ -210,7 +211,8 @@ namespace Kyoo.Core.Api
 		public async Task<MovieWatchStatus?> SetWatchStatus(
 			Identifier identifier,
 			WatchStatus status,
-			int? watchedTime
+			int? watchedTime,
+			int? percent
 		)
 		{
 			Guid id = await identifier.Match(
@@ -219,7 +221,7 @@ namespace Kyoo.Core.Api
 			);
 			return await _libraryManager
 				.WatchStatus
-				.SetMovieStatus(id, User.GetIdOrThrow(), status, watchedTime);
+				.SetMovieStatus(id, User.GetIdOrThrow(), status, watchedTime, percent);
 		}
 
 		/// <summary>

--- a/back/src/Kyoo.Postgresql/Migrations/20240120154137_RuntimeNullable.Designer.cs
+++ b/back/src/Kyoo.Postgresql/Migrations/20240120154137_RuntimeNullable.Designer.cs
@@ -2,17 +2,23 @@
 using System;
 using System.Collections.Generic;
 using Kyoo.Abstractions.Models;
+using Kyoo.Postgresql;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
 namespace Kyoo.Postgresql.Migrations
 {
 	[DbContext(typeof(PostgresContext))]
-	partial class PostgresContextModelSnapshot : ModelSnapshot
+	[Migration("20240120154137_RuntimeNullable")]
+	partial class RuntimeNullable
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/back/src/Kyoo.Postgresql/Migrations/20240120154137_RuntimeNullable.cs
+++ b/back/src/Kyoo.Postgresql/Migrations/20240120154137_RuntimeNullable.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kyoo.Postgresql.Migrations
+{
+	/// <inheritdoc />
+	public partial class RuntimeNullable : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AlterColumn<int>(
+				name: "runtime",
+				table: "movies",
+				type: "integer",
+				nullable: true,
+				oldClrType: typeof(int),
+				oldType: "integer"
+			);
+
+			migrationBuilder.AlterColumn<int>(
+				name: "runtime",
+				table: "episodes",
+				type: "integer",
+				nullable: true,
+				oldClrType: typeof(int),
+				oldType: "integer"
+			);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AlterColumn<int>(
+				name: "runtime",
+				table: "movies",
+				type: "integer",
+				nullable: false,
+				defaultValue: 0,
+				oldClrType: typeof(int),
+				oldType: "integer",
+				oldNullable: true
+			);
+
+			migrationBuilder.AlterColumn<int>(
+				name: "runtime",
+				table: "episodes",
+				type: "integer",
+				nullable: false,
+				defaultValue: 0,
+				oldClrType: typeof(int),
+				oldType: "integer",
+				oldNullable: true
+			);
+		}
+	}
+}

--- a/front/packages/models/src/resources/episode.base.ts
+++ b/front/packages/models/src/resources/episode.base.ts
@@ -49,7 +49,7 @@ export const BaseEpisodeP = withImages(
 		/**
 		 * How long is this movie? (in minutes).
 		 */
-		runtime: z.number().int(),
+		runtime: z.number().int().nullable(),
 		/**
 		 * The release date of this episode. It can be null if unknown.
 		 */

--- a/front/packages/models/src/resources/movie.ts
+++ b/front/packages/models/src/resources/movie.ts
@@ -61,7 +61,7 @@ export const MovieP = withImages(
 		/**
 		 * How long is this movie? (in minutes).
 		 */
-		runtime: z.number().int(),
+		runtime: z.number().int().nullable(),
 		/**
 		 * The date this movie aired. It can also be null if this is unknown.
 		 */

--- a/front/packages/models/src/resources/watch-info.ts
+++ b/front/packages/models/src/resources/watch-info.ts
@@ -107,6 +107,10 @@ export const WatchInfoP = z.object({
 	 */
 	sha: z.string(),
 	/**
+	 * The duration of the video (in seconds).
+	 */
+	length: z.number(),
+	/**
 	 * The internal path of the video file.
 	 */
 	path: z.string(),

--- a/front/packages/ui/src/details/episode.tsx
+++ b/front/packages/ui/src/details/episode.tsx
@@ -57,7 +57,8 @@ export const episodeDisplayNumber = (
 	return def;
 };
 
-export const displayRuntime = (runtime: number) => {
+export const displayRuntime = (runtime: number | null) => {
+	if (!runtime) return null;
 	if (runtime < 60) return `${runtime}min`;
 	return `${Math.floor(runtime / 60)}h${runtime % 60}`;
 };
@@ -300,22 +301,19 @@ export const EpisodeLine = ({
 						)}
 					</Skeleton>
 					<View {...css({ flexDirection: "row", alignItems: "center" })}>
-						{isLoading ||
-							(runtime && (
-								<Skeleton>
-									{isLoading || (
-										<SubP>
-											{/* Source https://www.i18next.com/translation-function/formatting#datetime */}
-											{[
-												releaseDate ? t("{{val, datetime}}", { val: releaseDate }) : null,
-												displayRuntime(runtime),
-											]
-												.filter((item) => item != null)
-												.join(" · ")}
-										</SubP>
-									)}
-								</Skeleton>
-							))}
+						<Skeleton>
+							{isLoading || (
+								<SubP>
+									{/* Source https://www.i18next.com/translation-function/formatting#datetime */}
+									{[
+										releaseDate ? t("{{val, datetime}}", { val: releaseDate }) : null,
+										displayRuntime(runtime),
+									]
+										.filter((item) => item != null)
+										.join(" · ")}
+								</SubP>
+							)}
+						</Skeleton>
 						{slug && watchedStatus !== undefined && (
 							<EpisodesContext
 								slug={slug}

--- a/front/packages/ui/src/player/index.tsx
+++ b/front/packages/ui/src/player/index.tsx
@@ -127,7 +127,7 @@ export const Player = ({ slug, type }: { slug: string; type: "episode" | "movie"
 				next={next}
 				previous={previous}
 			/>
-			{data && <WatchStatusObserver type={type} slug={data.slug} />}
+			{data && info && <WatchStatusObserver type={type} slug={data.slug} duration={info.length} />}
 			<View
 				{...css({
 					flexGrow: 1,

--- a/front/packages/ui/src/player/watch-status-observer.tsx
+++ b/front/packages/ui/src/player/watch-status-observer.tsx
@@ -28,9 +28,11 @@ import { playAtom, progressAtom } from "./state";
 export const WatchStatusObserver = ({
 	type,
 	slug,
+	duration,
 }: {
 	type: "episode" | "movie";
 	slug: string;
+	duration: number;
 }) => {
 	const account = useAccount();
 	const queryClient = useQueryClient();
@@ -47,9 +49,10 @@ export const WatchStatusObserver = ({
 				params: {
 					status: WatchStatusV.Watching,
 					watchedTime: Math.round(seconds),
+					percent: Math.round((seconds / duration) * 100),
 				},
 			}),
-		[_mutate, type, slug],
+		[_mutate, type, slug, duration],
 	);
 	const readProgress = useAtomCallback(
 		useCallback((get) => {

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -153,7 +153,7 @@ class TheMovieDatabase(Provider):
 				if movie["status"] == "Released"
 				else MovieStatus.PLANNED,
 				rating=round(float(movie["vote_average"]) * 10),
-				runtime=int(movie["runtime"]),
+				runtime=int(movie["runtime"]) if movie["runtime"] is not None else None,
 				studios=[self.to_studio(x) for x in movie["production_companies"]],
 				genres=[
 					self.genre_map[x["id"]]
@@ -498,7 +498,7 @@ class TheMovieDatabase(Provider):
 				season_number=episode["season_number"],
 				episode_number=episode["episode_number"],
 				absolute_number=absolute,
-				runtime=int(episode["runtime"]),
+				runtime=int(episode["runtime"]) if episode["runtime"] is not None else None,
 				release_date=datetime.strptime(episode["air_date"], "%Y-%m-%d").date()
 				if episode["air_date"]
 				else None,

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -498,7 +498,9 @@ class TheMovieDatabase(Provider):
 				season_number=episode["season_number"],
 				episode_number=episode["episode_number"],
 				absolute_number=absolute,
-				runtime=int(episode["runtime"]) if episode["runtime"] is not None else None,
+				runtime=int(episode["runtime"])
+				if episode["runtime"] is not None
+				else None,
 				release_date=datetime.strptime(episode["air_date"], "%Y-%m-%d").date()
 				if episode["air_date"]
 				else None,

--- a/scanner/providers/types/episode.py
+++ b/scanner/providers/types/episode.py
@@ -26,7 +26,7 @@ class Episode:
 	season_number: Optional[int]
 	episode_number: Optional[int]
 	absolute_number: Optional[int]
-	runtime: int
+	runtime: Optional[int]
 	release_date: Optional[date | int]
 	thumbnail: Optional[str]
 	external_id: dict[str, MetadataID]

--- a/scanner/providers/types/movie.py
+++ b/scanner/providers/types/movie.py
@@ -36,7 +36,7 @@ class Movie:
 	air_date: Optional[date | int]
 	status: Status
 	rating: int
-	runtime: int
+	runtime: Optional[int]
 	studios: list[Studio]
 	genres: list[Genre]
 	# TODO: handle staff


### PR DESCRIPTION
This allows the runtime value to be null if unknown. There is a new field percent that should be sent on the watch Status update. If it is not specified, but the duration of the item is known, it is calculated like it was before. If the duration is not known, the handler returns 400 and does not update.

Closes #279 