### PR TITLE
 Add default playmode setting & playmode error message

### DIFF
--- a/front/apps/mobile/app/_layout.tsx
+++ b/front/apps/mobile/app/_layout.tsx
@@ -21,7 +21,7 @@
 import "react-native-reanimated";
 
 import { PortalProvider } from "@gorhom/portal";
-import { ThemeSelector } from "@kyoo/primitives";
+import { SnackbarProvider, ThemeSelector } from "@kyoo/primitives";
 import { DownloadProvider } from "@kyoo/ui";
 import { AccountProvider, createQueryClient, storage, useUserTheme } from "@kyoo/models";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
@@ -144,7 +144,9 @@ export default function Root() {
 					<AccountProvider>
 						<DownloadProvider>
 							<NavigationThemeProvider>
-								<Slot />
+								<SnackbarProvider>
+									<Slot />
+								</SnackbarProvider>
 							</NavigationThemeProvider>
 						</DownloadProvider>
 					</AccountProvider>

--- a/front/apps/web/src/pages/_app.tsx
+++ b/front/apps/web/src/pages/_app.tsx
@@ -22,7 +22,13 @@ import "../polyfill";
 
 import { HydrationBoundary, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { HiddenIfNoJs, TouchOnlyCss, SkeletonCss, ThemeSelector } from "@kyoo/primitives";
+import {
+	HiddenIfNoJs,
+	TouchOnlyCss,
+	SkeletonCss,
+	ThemeSelector,
+	SnackbarProvider,
+} from "@kyoo/primitives";
 import { WebTooltip } from "@kyoo/primitives/src/tooltip.web";
 import {
 	AccountP,
@@ -138,21 +144,23 @@ const App = ({ Component, pageProps }: AppProps) => {
 						<HydrationBoundary state={queryState}>
 							<ThemeSelector theme={userTheme} font={{ normal: "inherit" }}>
 								<PortalProvider>
-									<GlobalCssTheme />
-									<Layout
-										page={
-											<Component
-												randomItems={
-													randomItems[Component.displayName!] ??
-													arrayShuffle((Component as QueryPage).randomItems ?? [])
-												}
-												{...props}
-											/>
-										}
-										randomItems={[]}
-										{...layoutProps}
-									/>
-									<Tooltip id="tooltip" positionStrategy={"fixed"} />
+									<SnackbarProvider>
+										<GlobalCssTheme />
+										<Layout
+											page={
+												<Component
+													randomItems={
+														randomItems[Component.displayName!] ??
+														arrayShuffle((Component as QueryPage).randomItems ?? [])
+													}
+													{...props}
+												/>
+											}
+											randomItems={[]}
+											{...layoutProps}
+										/>
+										<Tooltip id="tooltip" positionStrategy={"fixed"} />
+									</SnackbarProvider>
 								</PortalProvider>
 							</ThemeSelector>
 						</HydrationBoundary>

--- a/front/packages/models/src/accounts.tsx
+++ b/front/packages/models/src/accounts.tsx
@@ -99,11 +99,8 @@ export const AccountProvider = ({
 
 	// update user's data from kyoo un startup, it could have changed.
 	const selected = useMemo(() => accounts.find((x) => x.selected), [accounts]);
-	const controller = useMemo(() => {
-		const ret = new AbortController();
-		setTimeout(() => ret.abort(), 5_000);
-		return ret;
-	}, [selected]);
+	const controller = new AbortController();
+	setTimeout(() => controller.abort(), 5_000);
 	const user = useFetch({
 		path: ["auth", "me"],
 		parser: UserP,

--- a/front/packages/models/src/utils.ts
+++ b/front/packages/models/src/utils.ts
@@ -18,8 +18,11 @@
  * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { Platform } from "react-native";
 import { Movie, Show } from "./resources";
 import { z } from "zod";
+import { useMMKVString } from "react-native-mmkv";
+import { storage } from "./account-internal";
 
 export const zdate = z.coerce.date;
 
@@ -39,3 +42,15 @@ export const getDisplayDate = (data: Show | Movie) => {
 		return airDate.getFullYear().toString();
 	}
 };
+
+export const useLocalSetting = (setting: string, def: string) => {
+	if (Platform.OS === "web" && typeof window === "undefined") return [def, null!] as const;
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const [val, setter] = useMMKVString(`settings.${setting}`, storage);
+	return [val ?? def, setter] as const;
+};
+
+export const getLocalSetting = (setting: string, def: string) => {
+	if (Platform.OS === "web" && typeof window === "undefined") return def;
+	return storage.getString(`settings.${setting}`) ?? setting;
+}

--- a/front/packages/models/src/utils.ts
+++ b/front/packages/models/src/utils.ts
@@ -53,4 +53,4 @@ export const useLocalSetting = (setting: string, def: string) => {
 export const getLocalSetting = (setting: string, def: string) => {
 	if (Platform.OS === "web" && typeof window === "undefined") return def;
 	return storage.getString(`settings.${setting}`) ?? setting;
-}
+};

--- a/front/packages/primitives/src/index.ts
+++ b/front/packages/primitives/src/index.ts
@@ -31,6 +31,7 @@ export * from "./container";
 export * from "./divider";
 export * from "./progress";
 export * from "./slider";
+export * from "./snackbar";
 export * from "./alert";
 export * from "./menu";
 export * from "./popup";

--- a/front/packages/primitives/src/snackbar.tsx
+++ b/front/packages/primitives/src/snackbar.tsx
@@ -1,0 +1,114 @@
+/*
+ * Kyoo - A portable and vast media library solution.
+ * Copyright (c) Kyoo.
+ *
+ * See AUTHORS.md and LICENSE file in the project root for full license information.
+ *
+ * Kyoo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Kyoo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { usePortal } from "@gorhom/portal";
+import { ReactElement, createContext, useCallback, useContext, useRef } from "react";
+import { SwitchVariant } from "./themes";
+import { P } from "@expo/html-elements";
+import { View } from "react-native";
+import { min, percent, px } from "yoshiki/native";
+import { ts } from "./utils";
+import { Button } from "./button";
+import { imageBorderRadius } from "./constants";
+
+export type Snackbar = {
+	key?: string;
+	label: string;
+	duration: number;
+	actions: Action[];
+};
+
+export type Action = {
+	label: string;
+	icon: ReactElement;
+	action: () => void;
+};
+
+const SnackbarContext = createContext<(snackbar: Snackbar) => void>(null!);
+
+export const SnackbarProvider = ({ children }: { children: ReactElement | ReactElement[] }) => {
+	const { addPortal, removePortal } = usePortal();
+	const snackbars = useRef<Snackbar[]>([]);
+	const timeout = useRef<NodeJS.Timeout | null>(null);
+
+	const createSnackbar = useCallback(
+		(snackbar: Snackbar) => {
+			if (snackbar.key) snackbars.current = snackbars.current.filter((x) => snackbar.key !== x.key);
+			snackbars.current.unshift(snackbar);
+
+			if (timeout.current) return;
+			const updatePortal = () => {
+				const top = snackbars.current.pop();
+				if (!top) {
+					timeout.current = null;
+					return;
+				}
+
+				addPortal("snackbar", <Snackbar {...top} />);
+				timeout.current = setTimeout(() => {
+					removePortal("snackbar");
+					updatePortal();
+				}, snackbar.duration * 1000);
+			};
+			updatePortal();
+		},
+		[addPortal, removePortal],
+	);
+
+	return <SnackbarContext.Provider value={createSnackbar}>{children}</SnackbarContext.Provider>;
+};
+
+export const useSnackbar = () => {
+	return useContext(SnackbarContext);
+};
+
+const Snackbar = ({ label, actions }: Snackbar) => {
+	// TODO: take navbar height into account for setting the position of the snacbar.
+	return (
+		<SwitchVariant>
+			{({ css }) => (
+				<View
+					{...css({
+						position: "absolute",
+						left: 0,
+						right: 0,
+						bottom: ts(4),
+					})}
+				>
+					<View
+						{...css({
+							bg: (theme) => theme.background,
+							maxWidth: { sm: percent(75), md: percent(45), lg: px(500) },
+							margin: ts(1),
+							padding: ts(1),
+							flexDirection: "row",
+							borderRadius: imageBorderRadius,
+						})}
+					>
+						<P {...css({ flexGrow: 1, flexShrink: 1 })}>{label}</P>
+						{actions?.map((x, i) => (
+							<Button key={i} text={x.label} icon={x.icon} onPress={x.action} />
+						))}
+					</View>
+				</View>
+			)}
+		</SwitchVariant>
+	);
+};

--- a/front/packages/ui/src/player/index.tsx
+++ b/front/packages/ui/src/player/index.tsx
@@ -68,7 +68,15 @@ const mapData = (
 
 let firstSlug: string | null = null;
 
-export const Player = ({ slug, type }: { slug: string; type: "episode" | "movie" }) => {
+export const Player = ({
+	slug,
+	type,
+	t: startTimeP,
+}: {
+	slug: string;
+	type: "episode" | "movie";
+	t?: number;
+}) => {
 	const { css } = useYoshiki();
 	const { t } = useTranslation();
 	const router = useRouter();
@@ -78,25 +86,16 @@ export const Player = ({ slug, type }: { slug: string; type: "episode" | "movie"
 	const { data: info, error: infoError } = useFetch(Player.infoQuery(type, slug));
 	const previous =
 		data && data.type === "episode" && data.previousEpisode
-			? `/watch/${data.previousEpisode.slug}`
+			? `/watch/${data.previousEpisode.slug}?t=0`
 			: undefined;
 	const next =
 		data && data.type === "episode" && data.nextEpisode
-			? `/watch/${data.nextEpisode.slug}`
+			? `/watch/${data.nextEpisode.slug}?t=0`
 			: undefined;
 
 	useVideoKeyboard(info?.subtitles, info?.fonts, previous, next);
 
-	firstSlug ??= slug;
-	// can't use useRef since the player get's remonted everytime (don't know why)
-	useEffect(() => {
-		return () => {
-			if (!document.location.href.includes("/watch")) firstSlug = null;
-		};
-	}, [slug]);
-	// only use the start time when the player was inited with this episode/movie
-	// (don't actually resume an episode when you auto-play the next for example)
-	const startTime = firstSlug === slug ? data?.watchStatus?.watchedTime : 0;
+	const startTime = startTimeP ?? data?.watchStatus?.watchedTime;
 
 	const setFullscreen = useSetAtom(fullscreenAtom);
 	useEffect(() => {

--- a/front/packages/ui/src/player/state.tsx
+++ b/front/packages/ui/src/player/state.tsx
@@ -18,7 +18,7 @@
  * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Audio, Episode, Subtitle, useAccount } from "@kyoo/models";
+import { Audio, Episode, Subtitle, getLocalSetting, useAccount } from "@kyoo/models";
 import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useAtomCallback } from "jotai/utils";
 import { ElementRef, memo, useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
@@ -30,12 +30,13 @@ import { useTranslation } from "react-i18next";
 export const playAtom = atom(true);
 export const loadAtom = atom(false);
 
-// TODO: Default to auto or pristine depending on the user settings.
 export enum PlayMode {
 	Direct,
 	Hls,
 }
-export const playModeAtom = atom<PlayMode>(PlayMode.Direct);
+export const playModeAtom = atom<PlayMode>(
+	getLocalSetting("playmode", "direct") !== "auto" ? PlayMode.Direct : PlayMode.Hls,
+);
 
 export const bufferedAtom = atom(0);
 export const durationAtom = atom<number | undefined>(undefined);

--- a/front/packages/ui/src/player/state.tsx
+++ b/front/packages/ui/src/player/state.tsx
@@ -24,6 +24,8 @@ import { useAtomCallback } from "jotai/utils";
 import { ElementRef, memo, useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
 import NativeVideo, { VideoProps } from "./video";
 import { Platform } from "react-native";
+import { useSnackbar } from "@kyoo/primitives";
+import { useTranslation } from "react-i18next";
 
 export const playAtom = atom(true);
 export const loadAtom = atom(false);
@@ -188,6 +190,9 @@ export const Video = memo(function Video({
 		return () => document.removeEventListener("fullscreenchange", handler);
 	});
 
+	const createSnackbar = useSnackbar();
+	const { t } = useTranslation();
+
 	if (!source || !links) return null;
 	return (
 		<NativeVideo
@@ -218,6 +223,11 @@ export const Video = memo(function Video({
 			fonts={fonts}
 			subtitles={subtitles}
 			onMediaUnsupported={() => {
+				createSnackbar({
+					key: "unsuported",
+					label: t("player.unsupportedError"),
+					duration: 3,
+				});
 				if (mode == PlayMode.Direct) setPlayMode(PlayMode.Hls);
 			}}
 		/>

--- a/front/packages/ui/src/settings/base.tsx
+++ b/front/packages/ui/src/settings/base.tsx
@@ -18,7 +18,7 @@
  * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Account, User, queryFn, useAccount } from "@kyoo/models";
+import { User, queryFn, useAccount } from "@kyoo/models";
 import {
 	Container,
 	H1,

--- a/front/packages/ui/src/settings/base.tsx
+++ b/front/packages/ui/src/settings/base.tsx
@@ -122,6 +122,16 @@ export const useSetting = <Setting extends keyof User["settings"]>(setting: Sett
 				method: "PATCH",
 				body: { settings: { ...account!.settings, ...update } },
 			}),
+		onMutate: async (newSettings) => {
+			const next = { ...account!, settings: { ...account!.settings, ...newSettings } };
+			await queryClient.cancelQueries({ queryKey: ["auth", "me"] });
+			const previous = queryClient.getQueryData(["auth", "me"]);
+			queryClient.setQueryData(["auth", "me"], next);
+			return { previous, next };
+		},
+		onError: (_, __, context) => {
+			queryClient.setQueryData(["auth", "me"], context!.previous);
+		},
 		onSettled: async () => await queryClient.invalidateQueries({ queryKey: ["auth", "me"] }),
 	});
 

--- a/front/packages/ui/src/settings/playback.tsx
+++ b/front/packages/ui/src/settings/playback.tsx
@@ -19,11 +19,15 @@
  */
 
 import { Select } from "@kyoo/primitives";
+import { useLocalSetting } from "@kyoo/models";
 import { useTranslation } from "react-i18next";
+import { useSetAtom } from "jotai";
 import { Preference, SettingsContainer, useSetting } from "./base";
+import { PlayMode, playModeAtom } from "../player/state";
 
-import SubtitleLanguage from "@material-symbols/svg-400/rounded/closed_caption-fill.svg";
+import PlayModeI from "@material-symbols/svg-400/rounded/display_settings-fill.svg";
 import AudioLanguage from "@material-symbols/svg-400/rounded/music_note-fill.svg";
+import SubtitleLanguage from "@material-symbols/svg-400/rounded/closed_caption-fill.svg";
 
 // I gave up on finding a way to retrive this using the Intl api (probably does not exist)
 // Simply copy pasted the list of languages from https://www.localeplanet.com/api/codelist.json
@@ -32,6 +36,8 @@ const allLanguages = ["af", "agq", "ak", "am", "ar", "as", "asa", "ast", "az", "
 
 export const PlaybackSettings = () => {
 	const { t, i18n } = useTranslation();
+	const [playMode, setDefaultPlayMode] = useLocalSetting("playmode", "direct");
+	const setCurrentPlayMode = useSetAtom(playModeAtom);
 	const [audio, setAudio] = useSetting("audioLanguage")!;
 	const [subtitle, setSubtitle] = useSetting("subtitleLanguage")!;
 	const languages = new Intl.DisplayNames([i18n.language ?? "en"], {
@@ -41,6 +47,22 @@ export const PlaybackSettings = () => {
 
 	return (
 		<SettingsContainer title={t("settings.playback.label")}>
+			<Preference
+				icon={PlayModeI}
+				label={t("settings.playback.playmode.label")}
+				description={t("settings.playback.playmode.description")}
+			>
+				<Select
+					label={t("settings.playback.playmode.label")}
+					value={playMode}
+					onValueChange={(value) => {
+						setDefaultPlayMode(value);
+						setCurrentPlayMode(value === "direct" ? PlayMode.Direct : PlayMode.Hls);
+					}}
+					values={["direct", "auto"]}
+					getLabel={(key) => t(`player.${key}`)}
+				/>
+			</Preference>
 			<Preference
 				icon={AudioLanguage}
 				label={t("settings.playback.audioLanguage.label")}

--- a/front/translations/en.json
+++ b/front/translations/en.json
@@ -151,7 +151,8 @@
 		"direct": "Pristine",
 		"transmux": "Original",
 		"auto": "Auto",
-		"notInPristine": "Unavailable in pristine"
+		"notInPristine": "Unavailable in pristine",
+		"unsupportedError": "Video codec not supported, transcoding in progress..."
 	},
 	"search": {
 		"empty": "No result found. Try a different query."

--- a/front/translations/en.json
+++ b/front/translations/en.json
@@ -94,6 +94,10 @@
 		},
 		"playback": {
 			"label": "Playback",
+			"playmode": {
+				"label": "Default play mode",
+				"description": "The default play mode used on this client. Pristine is lighter on the server but does not allow automatic quality changes"
+			},
 			"audioLanguage": {
 				"label": "Audio language",
 				"description": "The default audio language used when playing multi-audio videos"

--- a/front/translations/fr.json
+++ b/front/translations/fr.json
@@ -150,7 +150,9 @@
 		"fullscreen": "Plein-écran",
 		"direct": "Pristine",
 		"transmux": "Original",
-		"auto": "Auto"
+		"auto": "Auto",
+		"notInPristine": "Non disponible en pristine",
+		"unsupportedError": "Video codec not supported, transcoding in progress..."
 	},
 	"search": {
 		"empty": "Aucun résultat trouvé. Essayer avec une autre recherche."

--- a/front/translations/fr.json
+++ b/front/translations/fr.json
@@ -94,6 +94,10 @@
 		},
 		"playback": {
 			"label": "Lecteur",
+			"playmode": {
+				"label": "Mode de lecture par default",
+				"description": "Mode de lecture par défaut utilisé sur ce client. Pristine est plus léger pour le serveur mais ne permet pas de modifier automatiquement la qualité"
+			},
 			"audioLanguage": {
 				"label": "Langue audio",
 				"description": "Langue audio par défaut utilisée lors de la lecture de vidéos multi-audio"


### PR DESCRIPTION
When the media can't be played in the selected quality, display an error on a snackbar.

Also allow the default playmode (direct or automatic transcode) to be selected in the user's settings.