### PR TITLE
Fix transcoder with some weird files

### DIFF
--- a/transcoder/src/audiostream.go
+++ b/transcoder/src/audiostream.go
@@ -18,8 +18,8 @@ func NewAudioStream(file *FileStream, idx int32) *AudioStream {
 	return ret
 }
 
-func (as *AudioStream) getOutPath() string {
-	return fmt.Sprintf("%s/segment-a%d-%%06d.ts", as.file.Out, as.index)
+func (as *AudioStream) getOutPath(encoder_id int) string {
+	return fmt.Sprintf("%s/segment-a%d-%d-%%d.ts", as.file.Out, as.index, encoder_id)
 }
 
 func (as *AudioStream) getTranscodeArgs(segments string) []string {

--- a/transcoder/src/audiostream.go
+++ b/transcoder/src/audiostream.go
@@ -22,6 +22,10 @@ func (as *AudioStream) getOutPath(encoder_id int) string {
 	return fmt.Sprintf("%s/segment-a%d-%d-%%d.ts", as.file.Out, as.index, encoder_id)
 }
 
+func (as *AudioStream) getFlags() Flags {
+	return AudioF
+}
+
 func (as *AudioStream) getTranscodeArgs(segments string) []string {
 	return []string{
 		"-map", fmt.Sprintf("0:a:%d", as.index),

--- a/transcoder/src/filestream.go
+++ b/transcoder/src/filestream.go
@@ -104,8 +104,13 @@ func GetKeyframes(path string) ([]float64, bool, error) {
 			return nil, false, err
 		}
 
-		// Only save keyframes with at least 3s betweens, we dont want a segment of 0.2s
-		if fpts-last < 3 {
+		// Before, we wanted to only save keyframes with at least 3s betweens
+		// to prevent segments of 0.2s but sometimes, the -f segment muxer discards
+		// the segment time and decide to cut at a random keyframe. Having every keyframe
+		// handled as a segment prevents that.
+		// if fpts-last < 3 {
+		if fpts == 0 {
+			// we still ignore a keyframe in 0 because we hard code it above
 			continue
 		}
 

--- a/transcoder/src/info.go
+++ b/transcoder/src/info.go
@@ -201,6 +201,8 @@ func GetInfo(path string) (*MediaInfo, error) {
 		attachments = make([]string, 0)
 	}
 
+	// fmt.Printf("%s", mi.Option("info_parameters", ""))
+
 	ret := MediaInfo{
 		Sha:  sha,
 		Path: path,
@@ -222,6 +224,7 @@ func GetInfo(path string) (*MediaInfo, error) {
 					Or(
 						mi.Parameter(mediainfo.StreamVideo, 0, "BitRate"),
 						mi.Parameter(mediainfo.StreamVideo, 0, "OverallBitRate"),
+						mi.Parameter(mediainfo.StreamVideo, 0, "BitRate_Nominal"),
 					),
 				),
 			}

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -137,7 +137,8 @@ func (ts *Stream) run(start int32) error {
 		"-i", ts.file.Path,
 		"-copyts",
 	}
-	if end != int32(len(ts.file.Keyframes)-1) {
+	// do not include -to if we want the file to go to the end
+	if end != int32(len(ts.file.Keyframes)) {
 		args = append(args,
 			"-to", fmt.Sprintf("%.6f", ts.file.Keyframes[end]),
 		)

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -104,7 +104,7 @@ func toSegmentStr(segments []float64) string {
 func (ts *Stream) run(start int32) error {
 	// Start the transcode up to the 100th segment (or less)
 	// Stop at the first finished segment
-	end := min(start+3, int32(len(ts.file.Keyframes)))
+	end := min(start+100, int32(len(ts.file.Keyframes)))
 	ts.lock.Lock()
 	for i := start; i < end; i++ {
 		if ts.isSegmentReady(i) || ts.isSegmentTranscoding(i) {

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -358,6 +358,12 @@ func (ts *Stream) GetSegment(segment int32) (string, error) {
 }
 
 func (ts *Stream) prerareNextSegements(segment int32) {
+	// Audio is way cheaper to create than video so we don't need to run them in advance
+	// Running it in advance might actually slow down the video encode since less compute
+	// power can be used so we simply disable that.
+	if ts.handle.getFlags()&VideoF == 0 {
+		return
+	}
 	ts.lock.RLock()
 	defer ts.lock.RUnlock()
 	for i := segment + 1; i <= min(segment+10, int32(len(ts.segments)-1)); i++ {

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -135,8 +135,12 @@ func (ts *Stream) run(start int32) error {
 
 		"-ss", fmt.Sprintf("%.6f", ts.file.Keyframes[start]),
 		"-i", ts.file.Path,
-		"-to", fmt.Sprintf("%.6f", ts.file.Keyframes[end]),
 		"-copyts",
+	}
+	if end != int32(len(ts.file.Keyframes)-1) {
+		args = append(args,
+			"-to", fmt.Sprintf("%.6f", ts.file.Keyframes[end]),
+		)
 	}
 	args = append(args, ts.handle.getTranscodeArgs(segments_str)...)
 	args = append(args, []string{

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -191,7 +191,7 @@ func (ts *Stream) run(start int32) error {
 				should_stop = true
 			} else {
 				close(ts.segments[segment])
-				if int32(len(ts.segments)) == segment+1 {
+				if segment == end-1 {
 					// file finished, ffmped will finish soon on it's own
 					should_stop = true
 				} else if ts.isSegmentReady(segment + 1) {

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -184,7 +184,7 @@ func (ts *Stream) run(start int32) error {
 			// (because it searches for a keyframe)
 			// add back the time that would be lost otherwise
 			// this only appens when -to is before -i but having -to after -i gave a bug (not sure, don't remember)
-			end_ref += start_ref-ts.file.Keyframes[start-1]
+			end_ref += start_ref - ts.file.Keyframes[start-1]
 		}
 		args = append(args,
 			"-to", fmt.Sprintf("%.6f", end_ref),

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -145,6 +145,7 @@ func (ts *Stream) run(start int32) error {
 	args = append(args, ts.handle.getTranscodeArgs(segments_str)...)
 	args = append(args, []string{
 		"-f", "segment",
+		"-segment_time_delta", "0.2",
 		"-segment_format", "mpegts",
 		"-segment_times", segments_str,
 		"-segment_start_number", fmt.Sprint(start),

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -124,7 +124,6 @@ func (ts *Stream) run(start int32) error {
 	args = append(args, ts.handle.getTranscodeArgs(segments_str)...)
 	args = append(args, []string{
 		"-f", "segment",
-		"-segment_time_delta", "0.2",
 		"-segment_format", "mpegts",
 		"-segment_times", segments_str,
 		"-segment_start_number", fmt.Sprint(start),

--- a/transcoder/src/tracker.go
+++ b/transcoder/src/tracker.go
@@ -182,9 +182,9 @@ func (t *Tracker) killOrphanedeheads(stream *Stream) {
 			if info.head == -1 {
 				continue
 			}
-			distance = min(Abs(info.head-head), distance)
+			distance = min(Abs(info.head-head.segment), distance)
 		}
-		if distance > 100 {
+		if distance > 20 {
 			log.Printf("Killing orphaned head %s %d", stream.file.Path, encoder_id)
 			stream.KillHead(encoder_id)
 		}

--- a/transcoder/src/tracker.go
+++ b/transcoder/src/tracker.go
@@ -177,6 +177,10 @@ func (t *Tracker) killOrphanedeheads(stream *Stream) {
 	defer stream.lock.Unlock()
 
 	for encoder_id, head := range stream.heads {
+		if head == DeletedHead {
+			continue
+		}
+
 		distance := int32(99999)
 		for _, info := range t.clients {
 			if info.head == -1 {

--- a/transcoder/src/videostream.go
+++ b/transcoder/src/videostream.go
@@ -18,6 +18,10 @@ func NewVideoStream(file *FileStream, quality Quality) *VideoStream {
 	return ret
 }
 
+func (vs *VideoStream) getFlags() Flags {
+	return VideoF
+}
+
 func (vs *VideoStream) getOutPath(encoder_id int) string {
 	return fmt.Sprintf("%s/segment-%s-%d-%%d.ts", vs.file.Out, vs.quality, encoder_id)
 }

--- a/transcoder/src/videostream.go
+++ b/transcoder/src/videostream.go
@@ -43,6 +43,10 @@ func (vs *VideoStream) getTranscodeArgs(segments string) []string {
 		"-maxrate", fmt.Sprint(vs.quality.MaxBitrate()),
 		// Force segments to be split exactly on keyframes (only works when transcoding)
 		"-force_key_frames", segments,
+		// sc_threshold is a scene detection mechanisum used to create a keyframe when the scene changes
+		// this is on by default and inserts keyframes where we don't want to (it also breaks force_key_frames)
+		// we disable it to prevents whole scenes from behing removed due to the -f segment failing to find the corresonding keyframe
+		"-sc_threshold", "0",
 		"-strict", "-2",
 	}
 }

--- a/transcoder/src/videostream.go
+++ b/transcoder/src/videostream.go
@@ -18,8 +18,8 @@ func NewVideoStream(file *FileStream, quality Quality) *VideoStream {
 	return ret
 }
 
-func (vs *VideoStream) getOutPath() string {
-	return fmt.Sprintf("%s/segment-%s-%%06d.ts", vs.file.Out, vs.quality)
+func (vs *VideoStream) getOutPath(encoder_id int) string {
+	return fmt.Sprintf("%s/segment-%s-%d-%%d.ts", vs.file.Out, vs.quality, encoder_id)
 }
 
 func (vs *VideoStream) getTranscodeArgs(segments string) []string {


### PR DESCRIPTION
Weird thinks i found:

 - `-copyts` is mandatory for hls
 - ffmpeg has a scene detection tool than auto-insert keyframes (this breaks forced keyframes)
 - `-ss` seeks to the keyframe prior the given time when in `noaccurate_seek` mode (or in `-c:v copy`). if the given time is a keyframe, this is UB
 - `-to` used before `-i` actually compute the duration needed (by doing `-to` minus `-ss`) but since `-ss` seeks back to the previous keyframe, `-to` actually ends prior to the requested end in those cases
 - `-segment_times` requires times relative to 0 whereas `-forced_keyframes` require times relative to ts