### PR TITLE
Fix transcode for files that does not start at 0ms

### DIFF
--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -166,14 +166,16 @@ func (ts *Stream) run(start int32) error {
 		"-nostats", "-hide_banner", "-loglevel", "warning",
 	}
 
-	if ts.handle.getFlags()&VideoF != 0 {
-		// This is the default behavior in transmux mode and needed to force pre/post segment to work
-		// This must be disabled when processing only audio because it creates gaps in audio
-		args = append(args, "-noaccurate_seek")
+	if start_ref != 0 {
+		if ts.handle.getFlags()&VideoF != 0 {
+			// This is the default behavior in transmux mode and needed to force pre/post segment to work
+			// This must be disabled when processing only audio because it creates gaps in audio
+			args = append(args, "-noaccurate_seek")
+		}
+		args = append(args,
+			"-ss", fmt.Sprintf("%.6f", start_ref),
+		)
 	}
-	args = append(args,
-		"-ss", fmt.Sprintf("%.6f", start_ref),
-	)
 	// do not include -to if we want the file to go to the end
 	if end+1 < int32(len(ts.file.Keyframes)) {
 		// sometimes, the duration is shorter than expected (only during transcode it seems)


### PR DESCRIPTION
Video streams can, sometimes, start at a timestamp like 0:00.083. When this is the case, ffmpeg still reports keyframes from 0ms to this start time. This PR disables segments creations before the start time, before that ffmpeg tried to cope with this issue by duplicating some segments, so one could have audio delay when switching between encoder 0 to 1.