### PR TITLE
Add vaapi hardware acceleration

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -60,6 +60,28 @@ stop Kyoo's services. You can then remove the configuration files.
 
 # Hardware Acceleration
 
+## VA-API (intel, amd)
+
+First install necessary drivers on your system, when running `vainfo` you should have something like this:
+```
+libva info: VA-API version 1.20.0
+libva info: Trying to open /run/opengl-driver/lib/dri/iHD_drv_video.so
+libva info: Found init function __vaDriverInit_1_20
+libva info: va_openDriver() returns 0
+vainfo: VA-API version: 1.20 (libva 2.20.1)
+vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.3.5 ()
+vainfo: Supported profile and entrypoints
+      VAProfileH264Main               :	VAEntrypointVLD
+      VAProfileH264Main               :	VAEntrypointEncSlice
+      ...Truncated...
+      VAProfileHEVCSccMain444_10      :	VAEntrypointVLD
+      VAProfileHEVCSccMain444_10      :	VAEntrypointEncSliceLP
+```
+Kyoo will default to use your primary card (located at `/dev/dri/renderD128`). If you need to specify a secondary one, you
+can use the `GOTRANSCODER_VAAPI_RENDERER` env-var to specify `/dev/dri/renderD129` or another one.
+
+Then you can simply run kyoo using `docker compose --profile vaapi up -d` (notice the `--profile vaapi` added)
+
 ## Nvidia
 
 To enable nvidia hardware acceleration, first install necessary drivers on your system.
@@ -70,7 +92,7 @@ follow the instructions on the official webpage or your distribution wiki.
 To test if everything works, you can run `sudo docker run --rm --gpus all ubuntu nvidia-smi`. If your version of docker is older,
 you might need to add `--runtime nvidia` like so: `sudo docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi`
 
-After that, you can now use `docker compose --profile nvidia up -d` to start kyoo with nvidia hardware acceleration.
+After that, you can now use `docker compose --profile nvidia up -d` to start kyoo with nvidia hardware acceleration (notice the `--profile nvidia` added).
 
-Note that most nvidia cards have an artifical limit on the number of encodes. You can confirm your card limit [here](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new).
-This limit can also be remove by applying an [unofficial patch](https://github.com/keylase/nvidia-patch) to you driver.
+Note that most nvidia cards have an artificial limit on the number of encodes. You can confirm your card limit [here](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new).
+This limit can also be removed by applying an [unofficial patch](https://github.com/keylase/nvidia-patch) to you driver.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -87,6 +87,15 @@ services:
       - GOTRANSCODER_HWACCEL=nvidia
     profiles: ['nvidia']
 
+  transcoder-vaapi:
+    <<: *transcoder-base
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      - GOTRANSCODER_HWACCEL=vaapi
+      - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
+    profiles: ['vaapi']
+
   ingress:
     image: nginx
     restart: on-failure

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -95,6 +95,15 @@ services:
       - GOTRANSCODER_HWACCEL=vaapi
       - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
     profiles: ['vaapi']
+  # qsv is the same setup as vaapi but with the hwaccel env var different
+  transcoder-qsv:
+    <<: *transcoder-base
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      - GOTRANSCODER_HWACCEL=qsv
+      - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
+    profiles: ['qsv']
 
   ingress:
     image: nginx

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,6 +64,15 @@ services:
       - GOTRANSCODER_HWACCEL=nvidia
     profiles: ['nvidia']
 
+  transcoder-vaapi:
+    <<: *transcoder-base
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      - GOTRANSCODER_HWACCEL=vaapi
+      - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
+    profiles: ['vaapi']
+
   ingress:
     image: nginx
     restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,6 +72,15 @@ services:
       - GOTRANSCODER_HWACCEL=vaapi
       - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
     profiles: ['vaapi']
+  # qsv is the same setup as vaapi but with the hwaccel env var different
+  transcoder-qsv:
+    <<: *transcoder-base
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      - GOTRANSCODER_HWACCEL=qsv
+      - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
+    profiles: ['qsv']
 
   ingress:
     image: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,15 @@ services:
       - GOTRANSCODER_HWACCEL=vaapi
       - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
     profiles: ['vaapi']
+  # qsv is the same setup as vaapi but with the hwaccel env var different
+  transcoder-qsv:
+    <<: *transcoder-base
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      - GOTRANSCODER_HWACCEL=qsv
+      - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
+    profiles: ['qsv']
 
   ingress:
     image: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,15 @@ services:
       - GOTRANSCODER_HWACCEL=nvidia
     profiles: ['nvidia']
 
+  transcoder-vaapi:
+    <<: *transcoder-base
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      - GOTRANSCODER_HWACCEL=vaapi
+      - GOTRANSCODER_VAAPI_RENDERER=${GOTRANSCODER_VAAPI_RENDERER:-/dev/dri/renderD128}
+    profiles: ['vaapi']
+
   ingress:
     image: nginx
     restart: on-failure

--- a/shell.nix
+++ b/shell.nix
@@ -27,7 +27,7 @@ in
       wgo
       mediainfo
       libmediainfo
-      ffmpeg
+      ffmpeg-full
       postgresql_15
       eslint_d
       prettierd

--- a/transcoder/Dockerfile
+++ b/transcoder/Dockerfile
@@ -33,8 +33,11 @@ RUN go build -o ./transcoder
 # we use trixie (debian's testing because ffmpeg on latest is v5 and we need v6)
 # https://packages.debian.org/bookworm/ffmpeg for version tracking
 FROM debian:trixie-slim
+RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update \
-	&& apt-get install --no-install-recommends --no-install-suggests -y ffmpeg libmediainfo-dev \
+	&& apt-get install --no-install-recommends --no-install-suggests -y \
+	ffmpeg libmediainfo-dev \
+	vainfo mesa-va-drivers intel-media-va-driver-non-free i965-va-driver-shaders \
 	&& apt-get clean autoclean -y \
 	&& apt-get autoremove -y \
 	&& rm -rf /var/lib/apt/lists/*

--- a/transcoder/Dockerfile
+++ b/transcoder/Dockerfile
@@ -33,11 +33,20 @@ RUN go build -o ./transcoder
 # we use trixie (debian's testing because ffmpeg on latest is v5 and we need v6)
 # https://packages.debian.org/bookworm/ffmpeg for version tracking
 FROM debian:trixie-slim
+
+# read target arch from buildx or default to amd64 if using legacy builder.
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH:-amd64}
+RUN echo $TARGETARCH
 RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.sources
-RUN apt-get update \
+RUN set -x && apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
+	# runtime dependencies
 	ffmpeg libmediainfo-dev \
-	vainfo mesa-va-drivers intel-media-va-driver-non-free i965-va-driver-shaders \
+	# hwaccel dependencies
+	vainfo mesa-va-drivers \
+	# intel hwaccel dependencies, not available everywhere
+	$([ " $TARGETARCH" = " amd64" ] && echo "intel-media-va-driver-non-free i965-va-driver-shaders") \
 	&& apt-get clean autoclean -y \
 	&& apt-get autoremove -y \
 	&& rm -rf /var/lib/apt/lists/*

--- a/transcoder/Dockerfile.dev
+++ b/transcoder/Dockerfile.dev
@@ -23,9 +23,15 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 RUN update-ca-certificates
 
 RUN go install github.com/bokwoon95/wgo@latest
+RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
-	ffmpeg libavformat-dev libavutil-dev libswscale-dev libmediainfo-dev \
+	# runtime dependencies
+	ffmpeg libavformat-dev \
+	# build dependencies
+	libavutil-dev libswscale-dev libmediainfo-dev \
+	# hwaccel dependencies
+	vainfo mesa-va-drivers intel-media-va-driver-non-free i965-va-driver-shaders \
 	&& apt-get clean autoclean -y \
 	&& apt-get autoremove -y
 WORKDIR /app

--- a/transcoder/Dockerfile.dev
+++ b/transcoder/Dockerfile.dev
@@ -23,6 +23,10 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 RUN update-ca-certificates
 
 RUN go install github.com/bokwoon95/wgo@latest
+
+# read target arch from buildx or default to amd64 if using legacy builder.
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH:-amd64}
 RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
@@ -31,7 +35,9 @@ RUN apt-get update \
 	# build dependencies
 	libavutil-dev libswscale-dev libmediainfo-dev \
 	# hwaccel dependencies
-	vainfo mesa-va-drivers intel-media-va-driver-non-free i965-va-driver-shaders \
+	vainfo mesa-va-drivers \
+	# intel hwaccel dependencies, not available everywhere
+	$([ " $TARGETARCH" = " amd64" ] && echo "intel-media-va-driver-non-free i965-va-driver-shaders") \
 	&& apt-get clean autoclean -y \
 	&& apt-get autoremove -y
 WORKDIR /app

--- a/transcoder/main.go
+++ b/transcoder/main.go
@@ -190,7 +190,7 @@ func (h *Handler) GetInfo(c echo.Context) error {
 	go src.ExtractThumbnail(
 		ret.Path,
 		route,
-		&sha,
+		sha,
 	)
 	return c.JSON(http.StatusOK, ret)
 }
@@ -265,11 +265,15 @@ func (h *Handler) GetThumbnails(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	sha, err := src.GetHash(path)
+	if err != nil {
+		return err
+	}
 
 	out, err := src.ExtractThumbnail(
 		path,
 		GetRoute(c),
-		nil,
+		sha,
 	)
 	if err != nil {
 		return err
@@ -289,11 +293,15 @@ func (h *Handler) GetThumbnailsVtt(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	sha, err := src.GetHash(path)
+	if err != nil {
+		return err
+	}
 
 	out, err := src.ExtractThumbnail(
 		path,
 		GetRoute(c),
-		nil,
+		sha,
 	)
 	if err != nil {
 		return err

--- a/transcoder/src/hwaccel.go
+++ b/transcoder/src/hwaccel.go
@@ -69,6 +69,7 @@ func DetectHardwareAccel() HwAccelT {
 			Name: name,
 			DecodeFlags: []string{
 				"-hwaccel", "qsv",
+				// "-qsv_device", GetEnvOr("GOTRANSCODER_QSV_RENDERER", "/dev/dri/renderD128"),
 				"-hwaccel_output_format", "qsv",
 			},
 			EncodeFlags: []string{

--- a/transcoder/src/hwaccel.go
+++ b/transcoder/src/hwaccel.go
@@ -17,7 +17,7 @@ func DetectHardwareAccel() HwAccelT {
 			EncodeFlags: []string{
 				"-c:v", "libx264",
 				// superfast or ultrafast would produce a file extremly big so we prever veryfast or faster.
-				"-preset", "faster",
+				"-preset", "fast",
 				// sc_threshold is a scene detection mechanisum used to create a keyframe when the scene changes
 				// this is on by default and inserts keyframes where we don't want to (it also breaks force_key_frames)
 				// we disable it to prevents whole scenes from behing removed due to the -f segment failing to find the corresonding keyframe
@@ -63,6 +63,19 @@ func DetectHardwareAccel() HwAccelT {
 				// "-vf", "format=nv12|vaapi,hwupload",
 			},
 			ScaleFilter: "scale_vaapi=%d:%d",
+		}
+	case "qsv", "intel":
+		return HwAccelT{
+			Name: name,
+			DecodeFlags: []string{
+				"-hwaccel", "qsv",
+				"-hwaccel_output_format", "qsv",
+			},
+			EncodeFlags: []string{
+				"-c:v", "h264_qsv",
+				"-preset", "fast",
+			},
+			ScaleFilter: "scale_qsv=%d:%d",
 		}
 	default:
 		log.Printf("No hardware accelerator named: %s", name)

--- a/transcoder/src/thumbnails.go
+++ b/transcoder/src/thumbnails.go
@@ -27,15 +27,8 @@ type Thumbnail struct {
 
 var thumbnails = NewCMap[string, *Thumbnail]()
 
-func ExtractThumbnail(path string, route string, sha *string) (string, error) {
-	ret, _ := thumbnails.GetOrCreate(path, func() *Thumbnail {
-		if sha == nil {
-			nsha, err := GetHash(path)
-			if err != nil {
-				return nil
-			}
-			sha = &nsha
-		}
+func ExtractThumbnail(path string, route string, sha string) (string, error) {
+	ret, _ := thumbnails.GetOrCreate(sha, func() *Thumbnail {
 		ret := &Thumbnail{
 			path: fmt.Sprintf("%s/%s", Settings.Metadata, sha),
 		}


### PR DESCRIPTION
Also adds quicksync hardware acceleration but the new drivers (oneVLP) are not packaged yet on my distro, so I could not test, will write usage doc (simple `--profile qsv` like the others) after testing it when drivers gets packaged.

PS: I think that apple devices does not use vaapi but videotoolbox.