### PR TITLE
 Fix movies sort by start/end air date on items routes

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -81,6 +81,7 @@ Kyoo will default to use your primary card (located at `/dev/dri/renderD128`). I
 can use the `GOTRANSCODER_VAAPI_RENDERER` env-var to specify `/dev/dri/renderD129` or another one.
 
 Then you can simply run kyoo using `docker compose --profile vaapi up -d` (notice the `--profile vaapi` added)
+You can also add `COMPOSE_PROFILES=vaapi` to your `.env` instead of adding the `--profile` flag.
 
 ## Nvidia
 
@@ -93,6 +94,7 @@ To test if everything works, you can run `sudo docker run --rm --gpus all ubuntu
 you might need to add `--runtime nvidia` like so: `sudo docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi`
 
 After that, you can now use `docker compose --profile nvidia up -d` to start kyoo with nvidia hardware acceleration (notice the `--profile nvidia` added).
+You can also add `COMPOSE_PROFILES=nvidia` to your `.env` instead of adding the `--profile` flag.
 
 Note that most nvidia cards have an artificial limit on the number of encodes. You can confirm your card limit [here](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new).
 This limit can also be removed by applying an [unofficial patch](https://github.com/keylase/nvidia-patch) to you driver.

--- a/back/src/Kyoo.Abstractions/Models/Resources/Movie.cs
+++ b/back/src/Kyoo.Abstractions/Models/Resources/Movie.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using EntityFrameworkCore.Projectables;
 using Kyoo.Abstractions.Controllers;
@@ -117,6 +118,14 @@ namespace Kyoo.Abstractions.Models
 
 		/// <inheritdoc />
 		public Image? Logo { get; set; }
+
+		[SerializeIgnore]
+		[Column("air_date")]
+		public DateTime? StartAir => AirDate;
+
+		[SerializeIgnore]
+		[Column("air_date")]
+		public DateTime? EndAir => AirDate;
 
 		/// <summary>
 		/// A video of a few minutes that tease the content.

--- a/front/packages/models/src/login.ts
+++ b/front/packages/models/src/login.ts
@@ -78,6 +78,7 @@ export const getTokenWJ = async (account?: Account | null): ReturnType<typeof ru
 		let token = account.token;
 
 		if (account.token.expire_at <= new Date(new Date().getTime() + 10 * 1000)) {
+			console.log("refreshing token for account", account.slug);
 			try {
 				token = await queryFn(
 					{

--- a/scanner/scanner/__init__.py
+++ b/scanner/scanner/__init__.py
@@ -1,4 +1,5 @@
 async def main():
+	import asyncio
 	import os
 	import logging
 	import sys
@@ -38,8 +39,9 @@ async def main():
 	) as client:
 		try:
 			scanner = Scanner(client, languages=languages.split(","), api_key=api_key)
-			await scanner.scan(path)
-			logging.info("Scan finished. Starting to monitor...")
-			await monitor(path, scanner)
+			await asyncio.gather(
+				monitor(path, scanner),
+				scanner.scan(path),
+			)
 		except ProviderError as e:
 			logging.error(e)

--- a/scanner/scanner/scanner.py
+++ b/scanner/scanner/scanner.py
@@ -54,6 +54,7 @@ class Scanner:
 		# We batch videos by 20 because too mutch at once kinda DDOS everything.
 		for group in batch(iter(videos), 20):
 			await asyncio.gather(*map(self.identify, group))
+		logging.info("Scan finished.")
 
 	async def get_registered_paths(self) -> List[str]:
 		paths = None


### PR DESCRIPTION
Also allow `One Piece S21E12.mkv` to be identified even if the first episode of s21 is registered as 900 on tmdb.