### PR TITLE
Use rfc6381 to prevent h265 playback issues

### DIFF
--- a/scanner/scanner/scanner.py
+++ b/scanner/scanner/scanner.py
@@ -7,6 +7,7 @@ import re
 from aiohttp import ClientSession
 from pathlib import Path
 from typing import List, Literal, Any
+from urllib.parse import quote
 from providers.provider import Provider, ProviderError
 from providers.types.collection import Collection
 from providers.types.show import Show
@@ -273,7 +274,7 @@ class Scanner:
 
 		if type is None or type == "movie":
 			async with self._client.delete(
-				f'{self._url}/movies?filter=path eq "{path}"',
+				f'{self._url}/movies?filter=path eq "{quote(path)}"',
 				headers={"X-API-Key": self._api_key},
 			) as r:
 				if not r.ok:
@@ -282,7 +283,7 @@ class Scanner:
 
 		if type is None or type == "episode":
 			async with self._client.delete(
-				f'{self._url}/episodes?filter=path eq "{path}"',
+				f'{self._url}/episodes?filter=path eq "{quote(path)}"',
 				headers={"X-API-Key": self._api_key},
 			) as r:
 				if not r.ok:
@@ -292,6 +293,6 @@ class Scanner:
 		if path in self.issues:
 			self.issues = filter(lambda x: x != path, self.issues)
 			await self._client.delete(
-				f'{self._url}/issues?filter=domain eq scanner and cause eq "{path}"',
+				f'{self._url}/issues?filter=domain eq scanner and cause eq "{quote(path)}"',
 				headers={"X-API-Key": self._api_key},
 			)

--- a/transcoder/src/codec.go
+++ b/transcoder/src/codec.go
@@ -1,0 +1,130 @@
+package src
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/zoriya/go-mediainfo"
+)
+
+// convert mediainfo to RFC 6381, waiting for either of those tickets to be resolved:
+//
+//	https://sourceforge.net/p/mediainfo/feature-requests/499
+//	https://trac.ffmpeg.org/ticket/6617
+//
+// this code is addapted from https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
+func GetMimeCodec(mi *mediainfo.File, kind mediainfo.StreamKind, i int) *string {
+	codec := Or(
+		mi.Parameter(kind, i, "InternetMediaType"),
+		mi.Parameter(kind, i, "Format"),
+	)
+
+	log.Printf("codec: %s", codec)
+	switch codec {
+	case "video/H264", "AVC":
+		ret := "avc1"
+		info := strings.Split(strings.ToLower(mi.Parameter(kind, i, "Format_Profile")), "@")
+
+		format := info[0]
+		switch format {
+		case "high":
+			ret += ".6400"
+		case "main":
+			ret += ".4D40"
+		case "baseline":
+			ret += ".42E0"
+		default:
+			// Default to constrained baseline if profile is invalid
+			ret += ".4240"
+		}
+
+		// level format is l3.1 for level 31
+		level := ParseFloat(info[1][1:])
+		log.Printf("%s %s %f", format, info[1], level)
+		ret += fmt.Sprintf("%02x", int(level*10))
+		return &ret
+
+	case "video/H265", "HEVC":
+		// The h265 syntax is a bit of a mystery at the time this comment was written.
+		// This is what I've found through various sources:
+		// FORMAT: [codecTag].[profile].[constraint?].L[level * 30].[UNKNOWN]
+		ret := "hvc1"
+		info := strings.Split(strings.ToLower(mi.Parameter(kind, i, "Format_Profile")), "@")
+
+		profile := info[0]
+		if profile == "main 10" {
+			ret += ".2.4"
+		} else {
+			ret += ".1.4"
+		}
+
+		level := ParseFloat(info[1][:1])
+		ret += fmt.Sprintf(".L%02X.BO", int(level*30))
+		return &ret
+
+	case "AV1":
+		// https://aomedia.org/av1/specification/annex-a/
+		// FORMAT: [codecTag].[profile].[level][tier].[bitDepth]
+		ret := "av01"
+		info := strings.Split(strings.ToLower(mi.Parameter(kind, i, "Format_Profile")), "@")
+
+		profile := info[0]
+		switch profile {
+		case "main":
+			ret += ".0"
+		case "high":
+			ret += ".1"
+		case "professional":
+			ret += ".2"
+		default:
+			// Default to Main
+			ret += ".0"
+		}
+
+		// level is not defined in mediainfo. using a default
+		// Default to the maximum defined level 6.3
+		level := 19
+
+		bitdepth := ParseUint(mi.Parameter(kind, i, "BitDepth"))
+		if bitdepth != 8 && bitdepth != 10 && bitdepth != 12 {
+			// Default to 8 bits
+			bitdepth = 8
+		}
+
+		tierflag := 'M'
+		ret += fmt.Sprintf(".%02X%c.%02d", level, tierflag, bitdepth)
+
+		return &ret
+
+	case "AAC":
+		ret := "mp4a"
+
+		profile := strings.ToLower(mi.Parameter(kind, i, "Format_AdditionalFeatures"))
+		switch profile {
+		case "he":
+			ret += ".40.5"
+		case "lc":
+			ret += ".40.2"
+		default:
+			ret += ".40.2"
+		}
+
+		return &ret
+
+	case "audio/opus", "Opus":
+		ret := "Opus"
+		return &ret
+
+	case "AC-3":
+		ret := "mp4a.a5"
+		return &ret
+
+	case "audio/x-flac", "FLAC":
+		ret := "fLaC"
+		return &ret
+
+	default:
+		return nil
+	}
+}

--- a/transcoder/src/filestream.go
+++ b/transcoder/src/filestream.go
@@ -81,6 +81,9 @@ func (fs *FileStream) GetMaster() string {
 			master += fmt.Sprintf("AVERAGE-BANDWIDTH=%d,", int(math.Min(bitrate*0.8, float64(transmux_quality.AverageBitrate()))))
 			master += fmt.Sprintf("BANDWIDTH=%d,", int(math.Min(bitrate, float64(transmux_quality.MaxBitrate()))))
 			master += fmt.Sprintf("RESOLUTION=%dx%d,", fs.Info.Video.Width, fs.Info.Video.Height)
+			if fs.Info.Video.MimeCodec != nil {
+				master += fmt.Sprintf("CODECS=\"%s\",", *fs.Info.Video.MimeCodec)
+			}
 			master += "AUDIO=\"audio\","
 			master += "CLOSED-CAPTIONS=NONE\n"
 			master += fmt.Sprintf("./%s/index.m3u8\n", Original)

--- a/transcoder/src/filestream.go
+++ b/transcoder/src/filestream.go
@@ -87,7 +87,7 @@ func (fs *FileStream) GetMaster() string {
 		}
 		aspectRatio := float32(fs.Info.Video.Width) / float32(fs.Info.Video.Height)
 		for _, quality := range Qualities {
-			if quality.Height() < fs.Info.Video.Quality.Height() && quality.AverageBitrate() < fs.Info.Video.Bitrate {
+			if quality.Height() < fs.Info.Video.Quality.Height() {
 				master += "#EXT-X-STREAM-INF:"
 				master += fmt.Sprintf("AVERAGE-BANDWIDTH=%d,", quality.AverageBitrate())
 				master += fmt.Sprintf("BANDWIDTH=%d,", quality.MaxBitrate())

--- a/transcoder/src/filestream.go
+++ b/transcoder/src/filestream.go
@@ -74,8 +74,8 @@ func (fs *FileStream) GetMaster() string {
 				break
 			}
 		}
-		// TODO: also check if the codec is valid in a hls before putting transmux
-		if true {
+		// original stream
+		{
 			bitrate := float64(fs.Info.Video.Bitrate)
 			master += "#EXT-X-STREAM-INF:"
 			master += fmt.Sprintf("AVERAGE-BANDWIDTH=%d,", int(math.Min(bitrate*0.8, float64(transmux_quality.AverageBitrate()))))
@@ -88,14 +88,21 @@ func (fs *FileStream) GetMaster() string {
 			master += "CLOSED-CAPTIONS=NONE\n"
 			master += fmt.Sprintf("./%s/index.m3u8\n", Original)
 		}
+
 		aspectRatio := float32(fs.Info.Video.Width) / float32(fs.Info.Video.Height)
+		transmux_codec := "avc1.640028"
+
 		for _, quality := range Qualities {
-			if quality.Height() < fs.Info.Video.Quality.Height() {
+			same_codec := fs.Info.Video.MimeCodec != nil && *fs.Info.Video.MimeCodec == transmux_codec
+			inc_lvl := quality.Height() < fs.Info.Video.Quality.Height() ||
+				(quality.Height() == fs.Info.Video.Quality.Height() && !same_codec)
+
+			if inc_lvl {
 				master += "#EXT-X-STREAM-INF:"
 				master += fmt.Sprintf("AVERAGE-BANDWIDTH=%d,", quality.AverageBitrate())
 				master += fmt.Sprintf("BANDWIDTH=%d,", quality.MaxBitrate())
 				master += fmt.Sprintf("RESOLUTION=%dx%d,", int(aspectRatio*float32(quality.Height())+0.5), quality.Height())
-				master += "CODECS=\"avc1.640028\","
+				master += fmt.Sprintf("CODECS=\"%s\",", transmux_codec)
 				master += "AUDIO=\"audio\","
 				master += "CLOSED-CAPTIONS=NONE\n"
 				master += fmt.Sprintf("./%s/index.m3u8\n", quality)


### PR DESCRIPTION
 - Add `mimeCodec` on /info for both audio and video that contains the rfc6381 of the codec
 - Add this codec info on transmux streams to prevents unsupported codecs from appearing on the player
 - Fix 10bits stream transcode using the proper ffmpeg flags
 - Disable bitrate check for levels as this is not needed anymore.
 - Fix the scanner delete method when `&` was present on the file's path.