### PR TITLE
chore: disable rate-limiting on renovate PR creation

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disableRateLimiting"],
   "minimumReleaseAge": "5 days",
   "ignorePaths": ["**/front/**"],
   "postUpdateOptions": [


### PR DESCRIPTION
By default renovate rate limits itself, I feel this is safe to turn off and let's us get all the PRs at once. It also help in that I can help tweak the config further by seeing the PRs opened.