### PR TITLE
chore: switch to softprops/action-gh-release

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -58,9 +58,7 @@ jobs:
           path: ./front/kyoo.apk
 
       - name: Upload release artifacts
-        uses: Roang-zero1/github-upload-release-artifacts-action@v2
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          args: ./front/kyoo.apk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: ./front/kyoo.apk


### PR DESCRIPTION
This is the action Github recommends on their deprecated action here: https://github.com/actions/upload-release-asset