### PR TITLE
scanner: quote path when deleting issues

### DIFF
--- a/scanner/providers/kyoo_client.py
+++ b/scanner/providers/kyoo_client.py
@@ -60,7 +60,7 @@ class KyooClient:
 
 	async def delete_issue(self, path: str):
 		async with self.client.delete(
-			f'{self._url}/issues?filter=domain eq scanner and cause eq "{path}"',
+			f'{self._url}/issues?filter=domain eq scanner and cause eq "{quote(path)}"',
 			headers={"X-API-Key": self._api_key},
 		) as r:
 			if not r.ok:


### PR DESCRIPTION
Removed here: https://github.com/zoriya/Kyoo/commit/a18fa7ebade0af79154a275b336dd458c9eaeb30

But it is needed for paths with special chars like `#` or `&`