### PR TITLE
scanner: supports tmdb episode groups with multiple groups

### DIFF
--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -562,6 +562,8 @@ class TheMovieDatabase(Provider):
 		try:
 			groups = await self.get(f"tv/{show_id}/episode_groups")
 			ep_count = max((x["episode_count"] for x in groups["results"]), default=0)
+			if ep_count == 0:
+				return None
 			# Filter only absolute groups that contains at least 75% of all episodes (to skip non maintained absolute ordering)
 			group_id = next(
 				(
@@ -575,8 +577,7 @@ class TheMovieDatabase(Provider):
 			if group_id is None:
 				return None
 			group = await self.get(f"tv/episode_group/{group_id}")
-			grp = next(iter(group["groups"]), None)
-			return grp["episodes"] if grp else None
+			return [ep for grp in group["groups"] for ep in grp["episodes"]]
 		except Exception as e:
 			logger.exception(
 				"Could not retrieve absolute ordering information", exc_info=e


### PR DESCRIPTION
Sometimes episodes groups in tmdb have multiple groups inside them, kyoo should use all of them instead of the first one.

Example episode group: https://www.themoviedb.org/tv/203819-d-argent-et-de-sang/episode_group/65a19141f04d010131792b95