### PR TITLE
Fix folder renaming

### DIFF
--- a/back/src/Kyoo.Core/Views/Admin/Misc.cs
+++ b/back/src/Kyoo.Core/Views/Admin/Misc.cs
@@ -30,7 +30,7 @@ namespace Kyoo.Core.Api;
 /// Private APIs only used for other services. Can change at any time without notice.
 /// </summary>
 [ApiController]
-[Permission(nameof(Misc), Kind.Read, Group = Group.Admin)]
+[PartialPermission(nameof(Misc), Group = Group.Admin)]
 public class Misc(MiscRepository repo) : BaseApi
 {
 	/// <summary>
@@ -38,10 +38,31 @@ public class Misc(MiscRepository repo) : BaseApi
 	/// </summary>
 	/// <returns>The list of paths known to Kyoo.</returns>
 	[HttpGet("/paths")]
+	[PartialPermission(Kind.Read)]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	public Task<ICollection<string>> GetAllPaths()
 	{
 		return repo.GetRegisteredPaths();
+	}
+
+	/// <summary>
+	/// Delete item at path.
+	/// </summary>
+	/// <param name="path">The path to delete.</param>
+	/// <param name="recursive">
+	/// If true, the path will be considered as a directory and every children will be removed.
+	/// </param>
+	/// <returns>Nothing</returns>
+	[HttpDelete("/paths")]
+	[PartialPermission(Kind.Delete)]
+	[ProducesResponseType(StatusCodes.Status204NoContent)]
+	public async Task<IActionResult> DeletePath(
+		[FromQuery] string path,
+		[FromQuery] bool recursive = false
+	)
+	{
+		await repo.DeletePath(path, recursive);
+		return NoContent();
 	}
 
 	/// <summary>
@@ -50,6 +71,7 @@ public class Misc(MiscRepository repo) : BaseApi
 	/// <param name="date">The upper limit for the refresh date.</param>
 	/// <returns>The items that should be refreshed before the given date</returns>
 	[HttpGet("/refreshables")]
+	[PartialPermission(Kind.Read)]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	public Task<ICollection<RefreshableItem>> GetAllPaths([FromQuery] DateTime? date)
 	{

--- a/scanner/matcher/parser/guess.py
+++ b/scanner/matcher/parser/guess.py
@@ -45,10 +45,11 @@ if __name__ == "__main__":
 		async with ClientSession() as client:
 			xem = TheXemClient(client)
 
+			advanced = any(x == "-a" for x in sys.argv)
 			ret = guessit(
 				sys.argv[1],
 				xem_titles=await xem.get_expected_titles(),
-				# extra_flags={"advanced": True},
+				extra_flags={"advanced": advanced},
 			)
 			print(json.dumps(ret, cls=GuessitEncoder, indent=4))
 

--- a/scanner/matcher/parser/rules.py
+++ b/scanner/matcher/parser/rules.py
@@ -54,7 +54,7 @@ class UnlistTitles(Rule):
 	consequence = [RemoveMatch, AppendMatch]
 
 	def when(self, matches: Matches, context) -> Any:
-		titles: List[Match] = matches.named("title")  # type: ignore
+		titles: List[Match] = matches.named("title", lambda x: x.tagged("title"))  # type: ignore
 
 		if not titles or len(titles) <= 1:
 			return

--- a/scanner/providers/kyoo_client.py
+++ b/scanner/providers/kyoo_client.py
@@ -104,29 +104,16 @@ class KyooClient:
 	async def delete(
 		self,
 		path: str,
-		type: Literal["episode", "movie"] | None = None,
 	):
 		logger.info("Deleting %s", path)
 
-		if type is None or type == "movie":
-			async with self.client.delete(
-				f'{self._url}/movies?filter=path eq "{quote(path)}"',
-				headers={"X-API-Key": self._api_key},
-			) as r:
-				if not r.ok:
-					logger.error(f"Request error: {await r.text()}")
-					r.raise_for_status()
-
-		if type is None or type == "episode":
-			async with self.client.delete(
-				f'{self._url}/episodes?filter=path eq "{quote(path)}"',
-				headers={"X-API-Key": self._api_key},
-			) as r:
-				if not r.ok:
-					logger.error(f"Request error: {await r.text()}")
-					r.raise_for_status()
-
-		await self.delete_issue(path)
+		async with self.client.delete(
+			f'{self._url}/paths?recursive=true&path={quote(path)}',
+			headers={"X-API-Key": self._api_key},
+		) as r:
+			if not r.ok:
+				logger.error(f"Request error: {await r.text()}")
+				r.raise_for_status()
 
 	async def get(self, path: str):
 		async with self.client.get(

--- a/scanner/providers/kyoo_client.py
+++ b/scanner/providers/kyoo_client.py
@@ -108,7 +108,7 @@ class KyooClient:
 		logger.info("Deleting %s", path)
 
 		async with self.client.delete(
-			f'{self._url}/paths?recursive=true&path={quote(path)}',
+			f"{self._url}/paths?recursive=true&path={quote(path)}",
 			headers={"X-API-Key": self._api_key},
 		) as r:
 			if not r.ok:

--- a/scanner/scanner/__init__.py
+++ b/scanner/scanner/__init__.py
@@ -14,7 +14,7 @@ async def main():
 	async with Publisher() as publisher, KyooClient() as client:
 		path = os.environ.get("SCANNER_LIBRARY_ROOT", "/video")
 		await asyncio.gather(
-			monitor(path, publisher),
-			scan(path, publisher, client),
+			monitor(path, publisher, client),
+			scan(path, publisher, client, remove_deleted=True),
 			refresh(publisher, client),
 		)

--- a/scanner/scanner/monitor.py
+++ b/scanner/scanner/monitor.py
@@ -1,16 +1,21 @@
 from logging import getLogger
+from os.path import isdir
 from watchfiles import awatch, Change
-
 from .publisher import Publisher
+from .scanner import scan
+from providers.kyoo_client import KyooClient
 
 logger = getLogger(__name__)
 
 
-async def monitor(path: str, publisher: Publisher):
+async def monitor(path: str, publisher: Publisher, client: KyooClient):
 	async for changes in awatch(path, ignore_permission_denied=True):
 		for event, file in changes:
 			if event == Change.added:
-				await publisher.add(file)
+				if isdir(file):
+					await scan(file, publisher, client)
+				else:
+					await publisher.add(file)
 			elif event == Change.deleted:
 				await publisher.delete(file)
 			elif event == Change.modified:

--- a/scanner/scanner/scanner.py
+++ b/scanner/scanner/scanner.py
@@ -9,7 +9,9 @@ from providers.kyoo_client import KyooClient
 logger = getLogger(__name__)
 
 
-async def scan(path: str, publisher: Publisher, client: KyooClient, remove_deleted = False):
+async def scan(
+	path: str, publisher: Publisher, client: KyooClient, remove_deleted=False
+):
 	logger.info("Starting the scan. It can take some times...")
 	ignore_pattern = None
 	try:
@@ -35,4 +37,3 @@ async def scan(path: str, publisher: Publisher, client: KyooClient, remove_delet
 
 	await asyncio.gather(*map(publisher.add, to_register))
 	logger.info(f"Scan finished for {path}.")
-


### PR DESCRIPTION
Closes #412 

When a folder gets deleted (or moved, since it's the same event), delete every file in the folder.
When a folder gets created, scan every file in it recursively.