### PR TITLE
 Use stable images ids to prevent duplicated 

### DIFF
--- a/back/src/Kyoo.Core/Controllers/MiscRepository.cs
+++ b/back/src/Kyoo.Core/Controllers/MiscRepository.cs
@@ -62,7 +62,7 @@ public class MiscRepository(
 		}.Select(x => GetSql(x));
 		string sql = string.Join(" union all ", queries);
 		IEnumerable<Image?> ret = await database.QueryAsync<Image?>(sql);
-		return ret.Where(x => x != null).ToArray() as Image[];
+		return ret.ToArray() as Image[];
 	}
 
 	public async Task DownloadMissingImages()

--- a/back/src/Kyoo.Core/Controllers/ThumbnailsManager.cs
+++ b/back/src/Kyoo.Core/Controllers/ThumbnailsManager.cs
@@ -24,7 +24,6 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml;
 using Blurhash.SkiaSharp;
 using Kyoo.Abstractions.Controllers;
 using Kyoo.Abstractions.Models;
@@ -80,7 +79,11 @@ public class ThumbnailsManager(
 		try
 		{
 			if (image.Id == Guid.Empty)
-				image.Id = Guid.NewGuid();
+			{
+				// Ensure stable ids to prevent duplicated images being stored on the fs.
+				using MD5 md5 = MD5.Create();
+				image.Id = new Guid(md5.ComputeHash(Encoding.UTF8.GetBytes(image.Source)));
+			}
 
 			logger.LogInformation("Downloading image {What}", what);
 


### PR DESCRIPTION
Since we were generating a new image id on every download, editing a resource would introduce a new image on the fs (even if it did exist).

Using ids generated from the image source url prevents this.