### PR TITLE
Poc anilist provider

### DIFF
--- a/scanner/providers/implementations/anilist.py
+++ b/scanner/providers/implementations/anilist.py
@@ -1,0 +1,155 @@
+import asyncio
+from aiohttp import ClientSession
+from datetime import date
+from logging import getLogger
+from typing import Awaitable, Callable, Dict, List, Optional, Any, TypeVar
+from itertools import accumulate, zip_longest
+
+from providers.utils import ProviderError
+from matcher.cache import cache
+
+from ..provider import Provider
+from ..types.movie import Movie, MovieTranslation, Status as MovieStatus
+from ..types.season import Season, SeasonTranslation
+from ..types.episode import Episode, EpisodeTranslation, PartialShow, EpisodeID
+from ..types.studio import Studio
+from ..types.genre import Genre
+from ..types.metadataid import MetadataID
+from ..types.show import Show, ShowTranslation, Status as ShowStatus
+from ..types.collection import Collection, CollectionTranslation
+
+logger = getLogger(__name__)
+
+
+class AniList(Provider):
+	def __init__(
+		self,
+		languages: list[str],
+		client: ClientSession,
+		api_key: str,
+	) -> None:
+		super().__init__()
+		self._languages = languages
+		self._client = client
+		self.base = "https://graphql.anilist.co"
+		self.api_key = api_key
+
+	@property
+	def name(self) -> str:
+		return "anilist"
+
+	async def get(self, query: str, **variables: Optional[str]):
+		async with self._client.post(
+			self.base, json={"query": query, "variables": variables}
+		) as r:
+			r.raise_for_status()
+			return await r.json()
+
+	async def queryAnime(self, id: Optional[str], search: Optional[str]) -> Show:
+		query = """
+		{
+		  Media(id: $id, search: $search, type: ANIME) {
+		    id
+		    idMal
+		    title {
+		      romaji
+		      english
+		      native
+		    }
+		    description(asHtml: false)
+			status
+		    startDate {
+		      year
+		      month
+		      day
+		    }
+		    endDate {
+		      year
+		      month
+		      day
+		    }
+		    countryOfOrigin
+		    trailer {
+		      id
+		      site
+		    }
+		    coverImage {
+		      extraLarge
+		    }
+		    bannerImage
+		    genres
+		    synonyms
+		    averageScore
+		    tags {
+		      name
+		      isMediaSpoiler
+		      isGeneralSpoiler
+		    }
+		    studios(isMain: true) {
+		      nodes {
+		        id
+		        name
+		        siteUrl
+		      }
+		    }
+		    relations {
+		      edges {
+		        id
+		        relationType
+		        node {
+		          id
+		          title {
+		            romaji
+		            english
+		            native
+		          }
+		        }
+		      }
+		    }
+		  }
+		}
+		"""
+		ret = await self.get(query, id=id, search=search)
+		return Show(
+			translations={
+				"en": ShowTranslation(
+					name=ret["titles"]["romaji"],
+					tagline=None,
+					# TODO: unmarkdown the desc
+					overview=ret["description"],
+					# TODO: add spoiler tags
+					tags=[
+						x["name"]
+						for x in ret["tags"]
+						if not x["isMediaSpoiler"] and not x["isGeneralSpoiler"]
+					],
+					posters=[ret["coverImage"]["extraLarge"]],
+					logos=[],
+					thumbnails=[],
+					trailers=[f"https://youtube.com/watch?q={ret['trailer']['id']}"]
+					if ret["trailer"]["site"] == "youtube"
+					else [],
+				)
+			},
+			original_language=ret["countryOfOrigin"],
+			aliases=[ret["titles"]["english"], ret["titles"]["native"]],
+			start_air=date(
+				year=ret["startDate"]["year"],
+				month=ret["startDate"]["month"],
+				day=ret["startDate"]["day"],
+			),
+			end_air=date(
+				year=ret["endDate"]["year"],
+				month=ret["endDate"]["month"],
+				day=ret["endDate"]["day"],
+			),
+			status=ShowStatus.FINISHED
+			if ret["status"] == "FINISHED"
+			else ShowStatus.AIRING,
+			rating=ret["averageScore"],
+			# TODO: fill that
+			studios=[],
+			genres=[],
+			external_id={},
+			seasons=[],
+		)

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -2,7 +2,7 @@ import asyncio
 from aiohttp import ClientSession
 from datetime import datetime, timedelta
 from logging import getLogger
-from typing import Awaitable, Callable, Dict, List, Optional, Any, TypeVar
+from typing import cast, Awaitable, Callable, Dict, List, Optional, Any, TypeVar
 from itertools import accumulate, zip_longest
 
 from providers.utils import ProviderError
@@ -635,7 +635,9 @@ class TheMovieDatabase(Provider):
 		show = await self.identify_show(show_id)
 		# Dont forget to ingore the special season (season_number 0)
 		seasons_nbrs = [x.season_number for x in show.seasons if x.season_number != 0]
-		seasons_eps = [x.episodes_count for x in show.seasons if x.season_number != 0]
+		seasons_eps = [
+			cast(int, x.episodes_count) for x in show.seasons if x.season_number != 0
+		]
 
 		if not any(seasons_nbrs):
 			return (None, None)
@@ -663,7 +665,7 @@ class TheMovieDatabase(Provider):
 			show = await self.identify_show(show_id)
 			return (
 				sum(
-					x.episodes_count
+					cast(int, x.episodes_count)
 					for x in show.seasons
 					if 0 < x.season_number < season
 				)

--- a/scanner/providers/provider.py
+++ b/scanner/providers/provider.py
@@ -23,6 +23,7 @@ class Provider:
 		providers = []
 
 		from providers.implementations.anilist import AniList
+
 		return AniList(client)
 
 		from providers.implementations.themoviedatabase import TheMovieDatabase
@@ -31,7 +32,6 @@ class Provider:
 		if tmdb != "disabled":
 			tmdb = TheMovieDatabase(languages, client, tmdb)
 			providers.append(tmdb)
-
 
 		if not any(providers):
 			raise ProviderError(

--- a/scanner/providers/provider.py
+++ b/scanner/providers/provider.py
@@ -22,12 +22,16 @@ class Provider:
 		languages = languages.split(",")
 		providers = []
 
+		from providers.implementations.anilist import AniList
+		return AniList(client)
+
 		from providers.implementations.themoviedatabase import TheMovieDatabase
 
 		tmdb = os.environ.get("THEMOVIEDB_APIKEY") or TheMovieDatabase.DEFAULT_API_KEY
 		if tmdb != "disabled":
 			tmdb = TheMovieDatabase(languages, client, tmdb)
 			providers.append(tmdb)
+
 
 		if not any(providers):
 			raise ProviderError(

--- a/scanner/providers/types/episode.py
+++ b/scanner/providers/types/episode.py
@@ -19,7 +19,7 @@ class EpisodeID:
 	show_id: str
 	season: Optional[int]
 	episode: int
-	link: str
+	link: Optional[str]
 
 
 @dataclass

--- a/scanner/providers/types/season.py
+++ b/scanner/providers/types/season.py
@@ -33,6 +33,7 @@ class Season:
 		return {
 			**asdict(self),
 			**asdict(self.translations[default_language]),
+			"episodes_count": 0,
 			"poster": next(iter(self.translations[default_language].posters), None),
 			"thumbnail": next(
 				iter(self.translations[default_language].thumbnails), None

--- a/scanner/providers/types/season.py
+++ b/scanner/providers/types/season.py
@@ -19,7 +19,7 @@ class Season:
 	season_number: int
 	# This is not used by kyoo, this is just used internaly by the TMDB provider.
 	# maybe this should be moved?
-	episodes_count: int
+	episodes_count: Optional[int]
 	start_air: Optional[date | int] = None
 	end_air: Optional[date | int] = None
 	external_id: dict[str, MetadataID] = field(default_factory=dict)

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -18,19 +18,22 @@ def format_date(date: date | int | None) -> str | None:
 
 def select_image(
 	self: Movie | Show,
-	type: Literal["posters"] | Literal["thumbnails"] | Literal["logos"],
+	kind: Literal["posters"] | Literal["thumbnails"] | Literal["logos"],
 ) -> str | None:
 	# For now, the API of kyoo only support one language so we remove the others.
 	default_language = os.environ["LIBRARY_LANGUAGES"].split(",")[0]
 	return next(
 		chain(
 			(
-				getattr(self.translations[self.original_language], type)
+				getattr(self.translations[self.original_language], kind)
 				if self.original_language
+				and self.original_language in self.translations
 				else []
 			),
-			getattr(self.translations[default_language], type),
-			*(getattr(x, type) for x in self.translations.values()),
+			getattr(self.translations[default_language], kind)
+			if default_language in self.translations
+			else [],
+			*(getattr(x, kind) for x in self.translations.values()),
 		),
 		None,
 	)


### PR DESCRIPTION
Only merging this, to keep the anilist provider implementation on the git history, will revert later.

This was an attempt at #466, but metadata from anilist are not good enough to be used without a complementary provider (bad images format/quality, missing info...).

The plan to move #466 forward is to use https://github.com/Anime-Lists/anime-lists/ with a tvdb provider and complement missing data with tmdb.