### PR TITLE
 Handle missing translations in scanner

### DIFF
--- a/scanner/matcher/matcher.py
+++ b/scanner/matcher/matcher.py
@@ -117,7 +117,7 @@ class Matcher:
 		)
 		episode.path = path
 		logger.debug("Got episode: %s", episode)
-		episode.show_id = await self.create_or_get_show(episode)
+		episode.show_id = await self.create_or_get_show(episode, title)
 
 		if episode.season_number is not None:
 			episode.season_id = await self.register_seasons(
@@ -141,7 +141,7 @@ class Matcher:
 		provider_id = collection.external_id[self._provider.name].data_id
 		return await create_collection(provider_id)
 
-	async def create_or_get_show(self, episode: Episode) -> str:
+	async def create_or_get_show(self, episode: Episode, fallback_name: str) -> str:
 		@cache(ttl=timedelta(days=1), cache=self._show_cache)
 		async def create_show(_: str):
 			# TODO: Check if a show with the same metadata id exists already on kyoo.
@@ -152,6 +152,7 @@ class Matcher:
 				if isinstance(episode.show, PartialShow)
 				else episode.show
 			)
+			show.file_title = fallback_name
 			# TODO: collections
 			logger.debug("Got show: %s", episode)
 			ret = await self._client.post("show", data=show.to_kyoo())

--- a/scanner/matcher/matcher.py
+++ b/scanner/matcher/matcher.py
@@ -87,6 +87,7 @@ class Matcher:
 
 	async def search_movie(self, title: str, year: Optional[int], path: str):
 		movie = await self._provider.search_movie(title, year)
+		movie.file_title = title
 		movie.path = path
 		logger.debug("Got movie: %s", movie)
 		movie_id = await self._client.post("movies", data=movie.to_kyoo())

--- a/scanner/providers/types/episode.py
+++ b/scanner/providers/types/episode.py
@@ -1,7 +1,8 @@
-import os
 from datetime import date
 from dataclasses import dataclass, field, asdict
 from typing import Optional
+
+from providers.utils import select_translation
 
 from .show import Show
 from .metadataid import MetadataID
@@ -24,8 +25,8 @@ class EpisodeID:
 
 @dataclass
 class EpisodeTranslation:
-	name: str
-	overview: Optional[str]
+	name: Optional[str]
+	overview: Optional[str] = None
 
 
 @dataclass
@@ -45,10 +46,9 @@ class Episode:
 	translations: dict[str, EpisodeTranslation] = field(default_factory=dict)
 
 	def to_kyoo(self):
-		# For now, the API of kyoo only support one language so we remove the others.
-		default_language = os.environ["LIBRARY_LANGUAGES"].split(",")[0]
+		trans = select_translation(self) or EpisodeTranslation("")
 		return {
 			**asdict(self),
-			**asdict(self.translations[default_language]),
+			**asdict(trans),
 			"show": None,
 		}

--- a/scanner/providers/types/season.py
+++ b/scanner/providers/types/season.py
@@ -1,7 +1,8 @@
-import os
 from datetime import date
 from dataclasses import dataclass, field, asdict
 from typing import Optional
+
+from providers.utils import select_translation, select_image
 
 from .metadataid import MetadataID
 
@@ -28,13 +29,10 @@ class Season:
 	translations: dict[str, SeasonTranslation] = field(default_factory=dict)
 
 	def to_kyoo(self):
-		# For now, the API of kyoo only support one language so we remove the others.
-		default_language = os.environ["LIBRARY_LANGUAGES"].split(",")[0]
+		trans = select_translation(self) or SeasonTranslation()
 		return {
 			**asdict(self),
-			**asdict(self.translations[default_language]),
-			"poster": next(iter(self.translations[default_language].posters), None),
-			"thumbnail": next(
-				iter(self.translations[default_language].thumbnails), None
-			),
+			**asdict(trans),
+			"poster": select_image(self, "posters"),
+			"thumbnail": select_image(self, "thumbnails"),
 		}

--- a/scanner/providers/types/show.py
+++ b/scanner/providers/types/show.py
@@ -22,13 +22,13 @@ class Status(str, Enum):
 class ShowTranslation:
 	name: str
 	tagline: Optional[str] = None
-	tags: list[str] = []
+	tags: list[str] = field(default_factory=list)
 	overview: Optional[str] = None
 
-	posters: list[str] = []
-	logos: list[str] = []
-	trailers: list[str] = []
-	thumbnails: list[str] = []
+	posters: list[str] = field(default_factory=list)
+	logos: list[str] = field(default_factory=list)
+	trailers: list[str] = field(default_factory=list)
+	thumbnails: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 from datetime import date
-from itertools import chain
 
 from typing import Literal
 
@@ -16,24 +17,33 @@ def format_date(date: date | int | None) -> str | None:
 	return date.isoformat()
 
 
+# For now, the API of kyoo only support one language so we remove the others.
+default_languages = os.environ["LIBRARY_LANGUAGES"].split(",")
+
+
+def select_translation(value: Movie | Show, *, prefer_orginal=False):
+	if (
+		prefer_orginal
+		and value.original_language
+		and value.original_language in value.translations
+	):
+		return value.translations[value.original_language]
+	for lang in default_languages:
+		if lang in value.translations:
+			return value.translations[lang]
+	return None
+
+
 def select_image(
-	self: Movie | Show,
-	type: Literal["posters"] | Literal["thumbnails"] | Literal["logos"],
+	value: Movie | Show,
+	kind: Literal["posters"] | Literal["thumbnails"] | Literal["logos"],
 ) -> str | None:
-	# For now, the API of kyoo only support one language so we remove the others.
-	default_language = os.environ["LIBRARY_LANGUAGES"].split(",")[0]
-	return next(
-		chain(
-			(
-				getattr(self.translations[self.original_language], type)
-				if self.original_language
-				else []
-			),
-			getattr(self.translations[default_language], type),
-			*(getattr(x, type) for x in self.translations.values()),
-		),
-		None,
+	trans = select_translation(value, prefer_orginal=True) or next(
+		iter(value.translations.values()), None
 	)
+	if trans is None:
+		return None
+	return getattr(trans, kind)
 
 
 class ProviderError(RuntimeError):

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import os
 from datetime import date
 
-from typing import Literal, Any
+from typing import TYPE_CHECKING, Literal, Any
 
-from providers.types.movie import Movie
-from providers.types.show import Show
-from providers.types.season import Season
-from providers.types.episode import Episode
-from providers.types.collection import Collection
+if TYPE_CHECKING:
+	from providers.types.movie import Movie
+	from providers.types.show import Show
+	from providers.types.season import Season
+	from providers.types.episode import Episode
+	from providers.types.collection import Collection
 
 type Resource = Movie | Show | Season | Episode | Collection
 
@@ -27,6 +28,9 @@ default_languages = os.environ["LIBRARY_LANGUAGES"].split(",")
 
 
 def select_translation(value: Resource, *, prefer_orginal=False) -> Any:
+	from providers.types.movie import Movie
+	from providers.types.show import Show
+
 	if (
 		prefer_orginal
 		and (isinstance(value, Movie) or isinstance(value, Show))

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import os
 from datetime import date
 
-from typing import Literal
+from typing import Literal, Any
 
 from providers.types.movie import Movie
 from providers.types.show import Show
+from providers.types.season import Season
+from providers.types.episode import Episode
+from providers.types.collection import Collection
+
+type Resource = Movie | Show | Season | Episode | Collection
 
 
 def format_date(date: date | int | None) -> str | None:
@@ -21,9 +26,10 @@ def format_date(date: date | int | None) -> str | None:
 default_languages = os.environ["LIBRARY_LANGUAGES"].split(",")
 
 
-def select_translation(value: Movie | Show, *, prefer_orginal=False):
+def select_translation(value: Resource, *, prefer_orginal=False) -> Any:
 	if (
 		prefer_orginal
+		and (isinstance(value, Movie) or isinstance(value, Show))
 		and value.original_language
 		and value.original_language in value.translations
 	):
@@ -35,7 +41,7 @@ def select_translation(value: Movie | Show, *, prefer_orginal=False):
 
 
 def select_image(
-	value: Movie | Show,
+	value: Resource,
 	kind: Literal["posters"] | Literal["thumbnails"] | Literal["logos"],
 ) -> str | None:
 	trans = select_translation(value, prefer_orginal=True) or next(


### PR DESCRIPTION
If the scanner could not find the requested translation, it would raise an error.
Up until now this was not an issue since TMDB always return us translations data, even if they don't have the data they return another language or placeholder data (ex `Episode 18` instead of a title).

This will prove problematic in the future, since TVDB and other providers will/migth not have the same behavior.

This issue was revealed in #491 since anilist only has english data and this issue also appears on the `feat/tvdb` branch.