### PR TITLE
Fix video miss-cut because of start offset

### DIFF
--- a/transcoder/utils.go
+++ b/transcoder/utils.go
@@ -19,7 +19,7 @@ var safe_path = src.GetEnvOr("GOCODER_SAFE_PATH", "/video")
 // Encode the version in the hash path to update cached values.
 // Older versions won't be deleted (needed to allow multiples versions of the transcoder to run at the same time)
 // If the version changes a lot, we might want to automatically delete older versions.
-var version = "v2-"
+var version = "v3-"
 
 func GetPath(c echo.Context) (string, string, error) {
 	key := c.Param("path")


### PR DESCRIPTION
Sometimes, videos can start at a timing greater than 0:00. We need to take that into account and only list keyframes that come after the start of the video (without that, our segments count mismatch and we can have the same segment twice on the stream).
                                                                                                             
We can't hardcode the first keyframe at 0 because the transcoder needs to reference durations of segments. To handle this edge case, when we fetch the segment n0, no seeking is done but duration is computed from the first keyframe (instead of 0)
