### PR TITLE
Add media type filter

### DIFF
--- a/front/packages/ui/src/browse/header.tsx
+++ b/front/packages/ui/src/browse/header.tsx
@@ -109,8 +109,6 @@ export const BrowseSettings = ({
 }) => {
 	const { css, theme } = useYoshiki();
 	const { t } = useTranslation();
-	const filters: string[] = [];
-	// TODO: implement filters in the front.
 
 	return (
 		<>
@@ -177,26 +175,6 @@ export const BrowseSettings = ({
 						))}
 					</Menu>
 				</View>
-			</View>
-			<View
-				{...css({
-					flexDirection: "row-reverse",
-					alignItems: "center",
-					marginX: ts(4),
-					marginY: ts(1),
-					zIndex: 1,
-				})}
-			>
-				{filters.length !== 0 && (
-					<View {...css({ flexGrow: 1, flexDirection: "row", alignItems: "center" })}>
-						{/*<Icon icon={Style} {...css({ marginX: ts(1) })} />*/}
-						{filters.map((x) => (
-							<div style={{paddingRight: ".25rem"}}>
-								<Chip key={x} label={x} size={"small"} />
-							</div>
-						))}
-					</View>
-				)}
 			</View>
 		</>
 	);

--- a/front/packages/ui/src/browse/header.tsx
+++ b/front/packages/ui/src/browse/header.tsx
@@ -56,13 +56,14 @@ const MediaTypeTrigger = forwardRef<View, PressableProps & { mediaType: MediaTyp
 		const { t } = useTranslation();
 		const labelKey =
 			mediaType !== MediaTypeAll ? `browse.mediatypekey.${mediaType.key}` : "browse.mediatypelabel";
+		const icon = mediaType !== MediaTypeAll ? mediaType?.icon ?? FilterList : FilterList;
 		return (
 			<PressableFeedback
 				ref={ref}
 				{...css({ flexDirection: "row", alignItems: "center" }, props as any)}
 				{...tooltip(t("browse.mediatype-tt"))}
 			>
-				<Icon icon={mediaType?.icon ?? FilterList} {...css({ paddingX: ts(0.5) })} />
+				<Icon icon={icon} {...css({ paddingX: ts(0.5) })} />
 				<P>{t(labelKey as any)}</P>
 			</PressableFeedback>
 		);

--- a/front/packages/ui/src/browse/header.tsx
+++ b/front/packages/ui/src/browse/header.tsx
@@ -18,27 +18,18 @@
  * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {
-	HR,
-	Icon,
-	IconButton,
-	Menu,
-	P,
-	PressableFeedback,
-	tooltip,
-	ts,
-} from "@kyoo/primitives";
+import { HR, Icon, IconButton, Menu, P, PressableFeedback, tooltip, ts } from "@kyoo/primitives";
 import ArrowDownward from "@material-symbols/svg-400/rounded/arrow_downward.svg";
 import ArrowUpward from "@material-symbols/svg-400/rounded/arrow_upward.svg";
 import GridView from "@material-symbols/svg-400/rounded/grid_view.svg";
 import Sort from "@material-symbols/svg-400/rounded/sort.svg";
 import FilterList from "@material-symbols/svg-400/rounded/filter_list.svg";
 import ViewList from "@material-symbols/svg-400/rounded/view_list.svg";
-import {forwardRef} from "react";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableProps, View } from "react-native";
 import { useYoshiki } from "yoshiki/native";
-import {Layout, MediaType, MediaTypeAll, SearchSort, SortOrd} from "./types";
+import { Layout, MediaType, MediaTypeAll, SearchSort, SortOrd } from "./types";
 
 const SortTrigger = forwardRef<View, PressableProps & { sortKey: string }>(function SortTrigger(
 	{ sortKey, ...props },
@@ -59,24 +50,24 @@ const SortTrigger = forwardRef<View, PressableProps & { sortKey: string }>(funct
 	);
 });
 
-const MediaTypeTrigger = forwardRef<View, PressableProps & { mediaType: MediaType }>(function MediaTypeTrigger(
-	{ mediaType, ...props },
-	ref,
-) {
-	const { css } = useYoshiki();
-	const { t } = useTranslation();
-	const labelKey = mediaType !== MediaTypeAll ? `browse.mediatypekey.${mediaType.key}` : "browse.mediatypelabel";
-	return (
-		<PressableFeedback
-			ref={ref}
-			{...css({ flexDirection: "row", alignItems: "center" }, props as any)}
-			{...tooltip(t("browse.mediatype-tt"))}
-		>
-			<Icon icon={mediaType?.icon ?? FilterList} {...css({ paddingX: ts(0.5) })} />
-			<P>{t(labelKey as any)}</P>
-		</PressableFeedback>
-	);
-});
+const MediaTypeTrigger = forwardRef<View, PressableProps & { mediaType: MediaType }>(
+	function MediaTypeTrigger({ mediaType, ...props }, ref) {
+		const { css } = useYoshiki();
+		const { t } = useTranslation();
+		const labelKey =
+			mediaType !== MediaTypeAll ? `browse.mediatypekey.${mediaType.key}` : "browse.mediatypelabel";
+		return (
+			<PressableFeedback
+				ref={ref}
+				{...css({ flexDirection: "row", alignItems: "center" }, props as any)}
+				{...tooltip(t("browse.mediatype-tt"))}
+			>
+				<Icon icon={mediaType?.icon ?? FilterList} {...css({ paddingX: ts(0.5) })} />
+				<P>{t(labelKey as any)}</P>
+			</PressableFeedback>
+		);
+	},
+);
 
 export const BrowseSettings = ({
 	availableSorts,

--- a/front/packages/ui/src/browse/header.tsx
+++ b/front/packages/ui/src/browse/header.tsx
@@ -29,7 +29,7 @@ import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableProps, View } from "react-native";
 import { useYoshiki } from "yoshiki/native";
-import { Layout, MediaType, MediaTypeAll, SearchSort, SortOrd } from "./types";
+import { Layout, type MediaType, MediaTypeAll, SearchSort, SortOrd } from "./types";
 
 const SortTrigger = forwardRef<View, PressableProps & { sortKey: string }>(function SortTrigger(
 	{ sortKey, ...props },

--- a/front/packages/ui/src/browse/header.tsx
+++ b/front/packages/ui/src/browse/header.tsx
@@ -95,65 +95,63 @@ export const BrowseSettings = ({
 	const { t } = useTranslation();
 
 	return (
-		<>
-			<View
-				{...css({
-					flexDirection: "row-reverse",
-					alignItems: "center",
-					marginX: ts(4),
-					marginY: ts(1),
-				})}
-			>
-				<View {...css({ flexDirection: "row" })}>
-					<Menu Trigger={SortTrigger} sortKey={sortKey}>
-						{availableSorts.map((x) => (
-							<Menu.Item
-								key={x}
-								label={t(`browse.sortkey.${x}` as any)}
-								selected={sortKey === x}
-								icon={
-									x !== SearchSort.Relevance
-										? sortOrd === SortOrd.Asc
-											? ArrowUpward
-											: ArrowDownward
-										: undefined
-								}
-								onSelect={() =>
-									setSort(x, sortKey === x && sortOrd === SortOrd.Asc ? SortOrd.Desc : SortOrd.Asc)
-								}
-							/>
-						))}
-					</Menu>
-					<HR orientation="vertical" />
-					<IconButton
-						icon={GridView}
-						onPress={() => setLayout(Layout.Grid)}
-						color={layout === Layout.Grid ? theme.accent : undefined}
-						{...tooltip(t("browse.switchToGrid"))}
-						{...css({ padding: ts(0.5), marginY: "auto" })}
-					/>
-					<IconButton
-						icon={ViewList}
-						onPress={() => setLayout(Layout.List)}
-						color={layout === Layout.List ? theme.accent : undefined}
-						{...tooltip(t("browse.switchToList"))}
-						{...css({ padding: ts(0.5), marginY: "auto" })}
-					/>
-				</View>
-				<View {...css({ flexGrow: 1, flexDirection: "row", alignItems: "center" })}>
-					<Menu Trigger={MediaTypeTrigger} mediaType={mediaType}>
-						{availableMediaTypes.map((x) => (
-							<Menu.Item
-								key={x.key}
-								label={t(`browse.mediatypekey.${x.key}` as any)}
-								selected={mediaType === x}
-								icon={x.icon}
-								onSelect={() => setMediaType(x)}
-							/>
-						))}
-					</Menu>
-				</View>
+		<View
+			{...css({
+				flexDirection: "row-reverse",
+				alignItems: "center",
+				marginX: ts(4),
+				marginY: ts(1),
+			})}
+		>
+			<View {...css({ flexDirection: "row" })}>
+				<Menu Trigger={SortTrigger} sortKey={sortKey}>
+					{availableSorts.map((x) => (
+						<Menu.Item
+							key={x}
+							label={t(`browse.sortkey.${x}` as any)}
+							selected={sortKey === x}
+							icon={
+								x !== SearchSort.Relevance
+									? sortOrd === SortOrd.Asc
+										? ArrowUpward
+										: ArrowDownward
+									: undefined
+							}
+							onSelect={() =>
+								setSort(x, sortKey === x && sortOrd === SortOrd.Asc ? SortOrd.Desc : SortOrd.Asc)
+							}
+						/>
+					))}
+				</Menu>
+				<HR orientation="vertical" />
+				<IconButton
+					icon={GridView}
+					onPress={() => setLayout(Layout.Grid)}
+					color={layout === Layout.Grid ? theme.accent : undefined}
+					{...tooltip(t("browse.switchToGrid"))}
+					{...css({ padding: ts(0.5), marginY: "auto" })}
+				/>
+				<IconButton
+					icon={ViewList}
+					onPress={() => setLayout(Layout.List)}
+					color={layout === Layout.List ? theme.accent : undefined}
+					{...tooltip(t("browse.switchToList"))}
+					{...css({ padding: ts(0.5), marginY: "auto" })}
+				/>
 			</View>
-		</>
+			<View {...css({ flexGrow: 1, flexDirection: "row", alignItems: "center" })}>
+				<Menu Trigger={MediaTypeTrigger} mediaType={mediaType}>
+					{availableMediaTypes.map((x) => (
+						<Menu.Item
+							key={x.key}
+							label={t(`browse.mediatypekey.${x.key}` as any)}
+							selected={mediaType === x}
+							icon={x.icon}
+							onSelect={() => setMediaType(x)}
+						/>
+					))}
+				</Menu>
+			</View>
+		</View>
 	);
 };

--- a/front/packages/ui/src/browse/header.tsx
+++ b/front/packages/ui/src/browse/header.tsx
@@ -19,7 +19,6 @@
  */
 
 import {
-	Chip,
 	HR,
 	Icon,
 	IconButton,
@@ -33,15 +32,13 @@ import ArrowDownward from "@material-symbols/svg-400/rounded/arrow_downward.svg"
 import ArrowUpward from "@material-symbols/svg-400/rounded/arrow_upward.svg";
 import GridView from "@material-symbols/svg-400/rounded/grid_view.svg";
 import Sort from "@material-symbols/svg-400/rounded/sort.svg";
-import Style from "@material-symbols/svg-400/rounded/style.svg";
 import FilterList from "@material-symbols/svg-400/rounded/filter_list.svg";
 import ViewList from "@material-symbols/svg-400/rounded/view_list.svg";
-import {type ComponentType, forwardRef} from "react";
+import {forwardRef} from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableProps, View } from "react-native";
 import { useYoshiki } from "yoshiki/native";
-import {AllMediaTypes, Layout, SearchSort, SortOrd} from "./types";
-import type {SvgProps} from "react-native-svg";
+import {Layout, MediaType, MediaTypeAll, SearchSort, SortOrd} from "./types";
 
 const SortTrigger = forwardRef<View, PressableProps & { sortKey: string }>(function SortTrigger(
 	{ sortKey, ...props },
@@ -62,13 +59,13 @@ const SortTrigger = forwardRef<View, PressableProps & { sortKey: string }>(funct
 	);
 });
 
-const MediaTypeTrigger = forwardRef<View, PressableProps & { mediaType?: MediaType }>(function MediaTypeTrigger(
+const MediaTypeTrigger = forwardRef<View, PressableProps & { mediaType: MediaType }>(function MediaTypeTrigger(
 	{ mediaType, ...props },
 	ref,
 ) {
 	const { css } = useYoshiki();
 	const { t } = useTranslation();
-	const labelKey = mediaType ? `browse.mediatypekey.${mediaType.key}` : "browse.mediatypelabel";
+	const labelKey = mediaType !== MediaTypeAll ? `browse.mediatypekey.${mediaType.key}` : "browse.mediatypelabel";
 	return (
 		<PressableFeedback
 			ref={ref}
@@ -80,11 +77,6 @@ const MediaTypeTrigger = forwardRef<View, PressableProps & { mediaType?: MediaTy
 		</PressableFeedback>
 	);
 });
-
-export interface MediaType {
-	key: string;
-	icon: ComponentType<SvgProps>;
-}
 
 export const BrowseSettings = ({
 	availableSorts,
@@ -102,8 +94,8 @@ export const BrowseSettings = ({
 	sortOrd: SortOrd;
 	setSort: (sort: string, ord: SortOrd) => void;
 	availableMediaTypes: MediaType[];
-	mediaType?: MediaType;
-	setMediaType: (mediaType?: MediaType) => void;
+	mediaType: MediaType;
+	setMediaType: (mediaType: MediaType) => void;
 	layout: Layout;
 	setLayout: (layout: Layout) => void;
 }) => {
@@ -164,13 +156,7 @@ export const BrowseSettings = ({
 								label={t(`browse.mediatypekey.${x.key}` as any)}
 								selected={mediaType === x}
 								icon={x.icon}
-								onSelect={() => {
-									if (mediaType === x || x === AllMediaTypes) {
-										setMediaType(undefined)
-									} else {
-										setMediaType(x)
-									}
-								}}
+								onSelect={() => setMediaType(x)}
 							/>
 						))}
 					</Menu>

--- a/front/packages/ui/src/browse/header.tsx
+++ b/front/packages/ui/src/browse/header.tsx
@@ -21,9 +21,9 @@
 import { HR, Icon, IconButton, Menu, P, PressableFeedback, tooltip, ts } from "@kyoo/primitives";
 import ArrowDownward from "@material-symbols/svg-400/rounded/arrow_downward.svg";
 import ArrowUpward from "@material-symbols/svg-400/rounded/arrow_upward.svg";
+import FilterList from "@material-symbols/svg-400/rounded/filter_list.svg";
 import GridView from "@material-symbols/svg-400/rounded/grid_view.svg";
 import Sort from "@material-symbols/svg-400/rounded/sort.svg";
-import FilterList from "@material-symbols/svg-400/rounded/filter_list.svg";
 import ViewList from "@material-symbols/svg-400/rounded/view_list.svg";
 import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";

--- a/front/packages/ui/src/browse/index.tsx
+++ b/front/packages/ui/src/browse/index.tsx
@@ -32,9 +32,17 @@ import { DefaultLayout } from "../layout";
 import { ItemGrid } from "./grid";
 import { BrowseSettings } from "./header";
 import { ItemList } from "./list";
-import {MediaTypeAll, Layout, MediaTypes, SortBy, SortOrd, MediaTypeKey, MediaType} from "./types";
+import {
+	MediaTypeAll,
+	Layout,
+	MediaTypes,
+	SortBy,
+	SortOrd,
+	MediaTypeKey,
+	MediaType,
+} from "./types";
 
-const { useParam } = createParam<{ sortBy?: string, mediaType?: string }>();
+const { useParam } = createParam<{ sortBy?: string; mediaType?: string }>();
 
 export const itemMap = (
 	item: LibraryItem,
@@ -52,9 +60,13 @@ export const itemMap = (
 		item.kind === "show" ? item.watchStatus?.unseenEpisodesCount ?? item.episodesCount! : null,
 });
 
-const query = (mediaType: MediaType, sortKey?: SortBy, sortOrd?: SortOrd): QueryIdentifier<LibraryItem> => {
+const query = (
+	mediaType: MediaType,
+	sortKey?: SortBy,
+	sortOrd?: SortOrd,
+): QueryIdentifier<LibraryItem> => {
 	const filter = mediaType !== MediaTypeAll ? `kind eq ${mediaType.key}` : undefined;
-	return ({
+	return {
 		parser: LibraryItemP,
 		path: ["items"],
 		infinite: true,
@@ -63,13 +75,13 @@ const query = (mediaType: MediaType, sortKey?: SortBy, sortOrd?: SortOrd): Query
 			filter,
 			fields: ["watchStatus", "episodesCount"],
 		},
-	});
-}
+	};
+};
 
 const getMediaTypeFromParam = (mediaTypeParam?: string): MediaType => {
-	const mediaTypeKey = mediaTypeParam as MediaTypeKey || MediaTypeKey.All;
-	return MediaTypes.find(t => t.key === mediaTypeKey) ?? MediaTypeAll;
-}
+	const mediaTypeKey = (mediaTypeParam as MediaTypeKey) || MediaTypeKey.All;
+	return MediaTypes.find((t) => t.key === mediaTypeKey) ?? MediaTypeAll;
+};
 
 export const BrowsePage: QueryPage = () => {
 	const [sort, setSort] = useParam("sortBy");
@@ -112,7 +124,5 @@ BrowsePage.getLayout = DefaultLayout;
 
 BrowsePage.getFetchUrls = ({ mediaType, sortBy }) => {
 	const mediaTypeObj = getMediaTypeFromParam(mediaType);
-	return[
-		query(mediaTypeObj, sortBy?.split("-")[0] as SortBy, sortBy?.split("-")[1] as SortOrd),
-	];
-}
+	return [query(mediaTypeObj, sortBy?.split("-")[0] as SortBy, sortBy?.split("-")[1] as SortOrd)];
+};

--- a/front/packages/ui/src/browse/index.tsx
+++ b/front/packages/ui/src/browse/index.tsx
@@ -33,13 +33,13 @@ import { ItemGrid } from "./grid";
 import { BrowseSettings } from "./header";
 import { ItemList } from "./list";
 import {
-	MediaTypeAll,
 	Layout,
+	type MediaType,
+	MediaTypeAll,
+	MediaTypeKey,
 	MediaTypes,
 	SortBy,
 	SortOrd,
-	MediaTypeKey,
-	type MediaType,
 } from "./types";
 
 const { useParam } = createParam<{ sortBy?: string; mediaType?: string }>();

--- a/front/packages/ui/src/browse/index.tsx
+++ b/front/packages/ui/src/browse/index.tsx
@@ -62,7 +62,7 @@ export const itemMap = (
 
 export const createFilterString = (mediaType: MediaType): string | undefined => {
 	return mediaType !== MediaTypeAll ? `kind eq ${mediaType.key}` : undefined;
-}
+};
 
 const query = (
 	mediaType: MediaType,

--- a/front/packages/ui/src/browse/index.tsx
+++ b/front/packages/ui/src/browse/index.tsx
@@ -85,7 +85,7 @@ const getMediaTypeFromParam = (mediaTypeParam?: string): MediaType => {
 
 export const BrowsePage: QueryPage = () => {
 	const [sort, setSort] = useParam("sortBy");
-	const [mediaTypeParam, setMediaTypeKey] = useParam("mediaType");
+	const [mediaTypeParam, setMediaTypeParam] = useParam("mediaType");
 	const sortKey = (sort?.split(":")[0] as SortBy) || SortBy.Name;
 	const sortOrd = (sort?.split(":")[1] as SortOrd) || SortOrd.Asc;
 	const [layout, setLayout] = useState(Layout.Grid);
@@ -108,7 +108,7 @@ export const BrowsePage: QueryPage = () => {
 					mediaType={mediaType}
 					availableMediaTypes={MediaTypes}
 					setMediaType={(mediaType) => {
-						setMediaTypeKey(mediaType.key);
+						setMediaTypeParam(mediaType.key);
 					}}
 					layout={layout}
 					setLayout={setLayout}

--- a/front/packages/ui/src/browse/index.tsx
+++ b/front/packages/ui/src/browse/index.tsx
@@ -60,25 +60,28 @@ export const itemMap = (
 		item.kind === "show" ? item.watchStatus?.unseenEpisodesCount ?? item.episodesCount! : null,
 });
 
+export const createFilterString = (mediaType: MediaType): string | undefined => {
+	return mediaType !== MediaTypeAll ? `kind eq ${mediaType.key}` : undefined;
+}
+
 const query = (
 	mediaType: MediaType,
 	sortKey?: SortBy,
 	sortOrd?: SortOrd,
 ): QueryIdentifier<LibraryItem> => {
-	const filter = mediaType !== MediaTypeAll ? `kind eq ${mediaType.key}` : undefined;
 	return {
 		parser: LibraryItemP,
 		path: ["items"],
 		infinite: true,
 		params: {
 			sortBy: sortKey ? `${sortKey}:${sortOrd ?? "asc"}` : "name:asc",
-			filter,
+			filter: createFilterString(mediaType),
 			fields: ["watchStatus", "episodesCount"],
 		},
 	};
 };
 
-const getMediaTypeFromParam = (mediaTypeParam?: string): MediaType => {
+export const getMediaTypeFromParam = (mediaTypeParam?: string): MediaType => {
 	const mediaTypeKey = (mediaTypeParam as MediaTypeKey) || MediaTypeKey.All;
 	return MediaTypes.find((t) => t.key === mediaTypeKey) ?? MediaTypeAll;
 };

--- a/front/packages/ui/src/browse/index.tsx
+++ b/front/packages/ui/src/browse/index.tsx
@@ -39,7 +39,7 @@ import {
 	SortBy,
 	SortOrd,
 	MediaTypeKey,
-	MediaType,
+	type MediaType,
 } from "./types";
 
 const { useParam } = createParam<{ sortBy?: string; mediaType?: string }>();

--- a/front/packages/ui/src/browse/types.ts
+++ b/front/packages/ui/src/browse/types.ts
@@ -19,8 +19,8 @@
  */
 
 import Collection from "@material-symbols/svg-400/rounded/collections_bookmark.svg";
-import TV from "@material-symbols/svg-400/rounded/tv.svg";
 import Movie from "@material-symbols/svg-400/rounded/movie.svg";
+import TV from "@material-symbols/svg-400/rounded/tv.svg";
 import All from "@material-symbols/svg-400/rounded/view_headline.svg";
 import type { ComponentType } from "react";
 import type { SvgProps } from "react-native-svg";

--- a/front/packages/ui/src/browse/types.ts
+++ b/front/packages/ui/src/browse/types.ts
@@ -18,6 +18,12 @@
  * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {MediaType} from "./header";
+import Collection from "@material-symbols/svg-400/rounded/collections_bookmark.svg";
+import TV from "@material-symbols/svg-400/rounded/tv.svg";
+import Movie from "@material-symbols/svg-400/rounded/movie.svg";
+import All from "@material-symbols/svg-400/rounded/view_headline.svg";
+
 export enum SortBy {
 	Name = "name",
 	StartAir = "startAir",
@@ -42,3 +48,24 @@ export enum Layout {
 	Grid,
 	List,
 }
+
+export const AllMediaTypes: MediaType = {
+	key: "all",
+	icon: All
+}
+
+export const MediaTypes: MediaType[] = [
+	AllMediaTypes,
+	{
+		key: "movie",
+		icon: Movie
+	},
+	{
+		key: "show",
+		icon: TV,
+	},
+	{
+		key: "collection",
+		icon: Collection
+	}
+];

--- a/front/packages/ui/src/browse/types.ts
+++ b/front/packages/ui/src/browse/types.ts
@@ -18,11 +18,12 @@
  * along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {MediaType} from "./header";
 import Collection from "@material-symbols/svg-400/rounded/collections_bookmark.svg";
 import TV from "@material-symbols/svg-400/rounded/tv.svg";
 import Movie from "@material-symbols/svg-400/rounded/movie.svg";
 import All from "@material-symbols/svg-400/rounded/view_headline.svg";
+import type {ComponentType} from "react";
+import type {SvgProps} from "react-native-svg";
 
 export enum SortBy {
 	Name = "name",
@@ -49,23 +50,35 @@ export enum Layout {
 	List,
 }
 
-export const AllMediaTypes: MediaType = {
-	key: "all",
+export enum MediaTypeKey{
+	All = "all",
+	Movie = "movie",
+	Show = "show",
+	Collection = "collection",
+}
+
+export interface MediaType {
+	key: MediaTypeKey;
+	icon: ComponentType<SvgProps>;
+}
+
+export const MediaTypeAll: MediaType = {
+	key: MediaTypeKey.All,
 	icon: All
 }
 
 export const MediaTypes: MediaType[] = [
-	AllMediaTypes,
+	MediaTypeAll,
 	{
-		key: "movie",
+		key: MediaTypeKey.Movie,
 		icon: Movie
 	},
 	{
-		key: "show",
+		key: MediaTypeKey.Show,
 		icon: TV,
 	},
 	{
-		key: "collection",
+		key: MediaTypeKey.Collection,
 		icon: Collection
 	}
 ];

--- a/front/packages/ui/src/browse/types.ts
+++ b/front/packages/ui/src/browse/types.ts
@@ -22,8 +22,8 @@ import Collection from "@material-symbols/svg-400/rounded/collections_bookmark.s
 import TV from "@material-symbols/svg-400/rounded/tv.svg";
 import Movie from "@material-symbols/svg-400/rounded/movie.svg";
 import All from "@material-symbols/svg-400/rounded/view_headline.svg";
-import type {ComponentType} from "react";
-import type {SvgProps} from "react-native-svg";
+import type { ComponentType } from "react";
+import type { SvgProps } from "react-native-svg";
 
 export enum SortBy {
 	Name = "name",
@@ -50,7 +50,7 @@ export enum Layout {
 	List,
 }
 
-export enum MediaTypeKey{
+export enum MediaTypeKey {
 	All = "all",
 	Movie = "movie",
 	Show = "show",
@@ -64,14 +64,14 @@ export interface MediaType {
 
 export const MediaTypeAll: MediaType = {
 	key: MediaTypeKey.All,
-	icon: All
-}
+	icon: All,
+};
 
 export const MediaTypes: MediaType[] = [
 	MediaTypeAll,
 	{
 		key: MediaTypeKey.Movie,
-		icon: Movie
+		icon: Movie,
 	},
 	{
 		key: MediaTypeKey.Show,
@@ -79,6 +79,6 @@ export const MediaTypes: MediaType[] = [
 	},
 	{
 		key: MediaTypeKey.Collection,
-		icon: Collection
-	}
+		icon: Collection,
+	},
 ];

--- a/front/packages/ui/src/search/index.tsx
+++ b/front/packages/ui/src/search/index.tsx
@@ -60,7 +60,6 @@ export const SearchPage: QueryPage<{ q?: string }> = ({ q }) => {
 	const [layout, setLayout] = useState(Layout.Grid);
 
 	const mediaType = getMediaTypeFromParam(mediaTypeParam);
-	console.log("search: mediaType", mediaType);
 	const LayoutComponent = layout === Layout.Grid ? ItemGrid : ItemList;
 
 	return (

--- a/front/packages/ui/src/search/index.tsx
+++ b/front/packages/ui/src/search/index.tsx
@@ -23,15 +23,15 @@ import { usePageStyle } from "@kyoo/primitives";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createParam } from "solito";
-import {createFilterString, getMediaTypeFromParam, itemMap} from "../browse";
+import { createFilterString, getMediaTypeFromParam, itemMap } from "../browse";
 import { ItemGrid } from "../browse/grid";
 import { BrowseSettings } from "../browse/header";
 import { ItemList } from "../browse/list";
-import {Layout, type MediaType, MediaTypes, SearchSort, SortOrd} from "../browse/types";
+import { Layout, type MediaType, MediaTypes, SearchSort, SortOrd } from "../browse/types";
 import { InfiniteFetch } from "../fetch-infinite";
 import { DefaultLayout } from "../layout";
 
-const { useParam } = createParam<{ sortBy?: string, mediaType?: string }>();
+const { useParam } = createParam<{ sortBy?: string; mediaType?: string }>();
 
 const query = (
 	mediaType: MediaType,
@@ -99,4 +99,4 @@ SearchPage.getFetchUrls = ({ q, sortBy, mediaType }) => {
 	return [
 		query(mediaTypeObj, q, sortBy?.split("-")[0] as SearchSort, sortBy?.split("-")[1] as SortOrd),
 	];
-}
+};

--- a/front/translations/en.json
+++ b/front/translations/en.json
@@ -43,6 +43,14 @@
 		"season": "Season {{number}}"
 	},
 	"browse": {
+		"mediatypekey": {
+			"all": "All",
+			"movie": "Movies",
+			"show": "Series",
+			"collection": "Collection"
+		},
+		"mediatype-tt": "Media Type",
+		"mediatypelabel": "Media Type",
 		"sortby": "Sort by {{key}}",
 		"sortby-tt": "Sort by",
 		"sortkey": {


### PR DESCRIPTION
# Background

The first step to adding a series of filters on the browse page.

Discord discussion: https://discord.com/channels/1216460898139635753/1241683417180143646/1241683417180143646

# Results

I've been working on a searchable multi-select drop down component but it's taking a bit longer than I had hoped as I haven't had a lot of time in the last few weeks. I feel like this would be the ideal way to filter things to genres where there are a lot of options and you might want to select multiple.

While working on that, and to get things started in this area, I thought we could add this basic Media Type filter which will allow users to select the media type they wish to browse. I thought the `Menu` component was suitable as there are only 3 options.

# Demo

![Screen Recording 2024-06-08 at 18 26 43](https://github.com/zoriya/Kyoo/assets/97430840/ab2d012c-6621-4d7c-95d2-17c68f55add3)