### PR TITLE
Add filter to meilisearch in backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ OIDC_SERVICE_PROFILE=https://url-of-the-profile-endpoint-of-the-oidc-service.com
 OIDC_SERVICE_SCOPE="the list of scopes space separeted like email identity"
 # Token authentication method as seen in https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
 # Supported values: ClientSecretBasic (default) or ClientSecretPost
-# If in doupt, leave this empty.
+# If in doubt, leave this empty.
 OIDC_SERVICE_AUTHMETHOD=ClientSecretBasic
 # on the previous list, service is the internal name of your service, you can add as many as you want.
 
@@ -80,6 +80,11 @@ POSTGRES_PASSWORD=KyooPassword
 POSTGRES_DB=kyooDB
 POSTGRES_SERVER=postgres
 POSTGRES_PORT=5432
+
+# Read by the api container to know if it should run meilisearch's migrations/sync
+# and download missing images. This is a good idea to only have one instance with this on
+# Note: it does not run postgres migrations, use the migration container for that.
+RUN_MIGRATIONS=true
 
 MEILI_HOST="http://meilisearch:7700"
 MEILI_MASTER_KEY="ghvjkgisbgkbgskegblfqbgjkebbhgwkjfb"

--- a/back/src/Kyoo.Abstractions/Controllers/ISearchManager.cs
+++ b/back/src/Kyoo.Abstractions/Controllers/ISearchManager.cs
@@ -38,6 +38,7 @@ public interface ISearchManager
 	public Task<SearchPage<ILibraryItem>.SearchResult> SearchItems(
 		string? query,
 		Sort<ILibraryItem> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<ILibraryItem>? include = default
 	);
@@ -98,6 +99,7 @@ public interface ISearchManager
 	public Task<SearchPage<Episode>.SearchResult> SearchEpisodes(
 		string? query,
 		Sort<Episode> sortBy,
+		Filter<Episode>? filter,
 		SearchPagination pagination,
 		Include<Episode>? include = default
 	);
@@ -113,6 +115,7 @@ public interface ISearchManager
 	public Task<SearchPage<Studio>.SearchResult> SearchStudios(
 		string? query,
 		Sort<Studio> sortBy,
+		Filter<Studio>? filter,
 		SearchPagination pagination,
 		Include<Studio>? include = default
 	);

--- a/back/src/Kyoo.Abstractions/Controllers/ISearchManager.cs
+++ b/back/src/Kyoo.Abstractions/Controllers/ISearchManager.cs
@@ -54,6 +54,7 @@ public interface ISearchManager
 	public Task<SearchPage<Movie>.SearchResult> SearchMovies(
 		string? query,
 		Sort<Movie> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<Movie>? include = default
 	);
@@ -69,6 +70,7 @@ public interface ISearchManager
 	public Task<SearchPage<Show>.SearchResult> SearchShows(
 		string? query,
 		Sort<Show> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<Show>? include = default
 	);
@@ -84,6 +86,7 @@ public interface ISearchManager
 	public Task<SearchPage<Collection>.SearchResult> SearchCollections(
 		string? query,
 		Sort<Collection> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<Collection>? include = default
 	);

--- a/back/src/Kyoo.Abstractions/Models/Utils/Filter.cs
+++ b/back/src/Kyoo.Abstractions/Models/Utils/Filter.cs
@@ -215,14 +215,16 @@ public abstract record Filter<T> : Filter
 					});
 			}
 
-			if (type == typeof(DateTime))
+			if (type == typeof(DateTime) || type == typeof(DateOnly))
 			{
 				return from year in Parse.Digit.Repeat(4).Text().Select(int.Parse)
 					from yd in Parse.Char('-')
-					from mouth in Parse.Digit.Repeat(2).Text().Select(int.Parse)
+					from month in Parse.Digit.Repeat(2).Text().Select(int.Parse)
 					from md in Parse.Char('-')
 					from day in Parse.Digit.Repeat(2).Text().Select(int.Parse)
-					select new DateTime(year, mouth, day) as object;
+					select type == typeof(DateTime)
+						? new DateTime(year, month, day) as object
+						: new DateOnly(year, month, day) as object;
 			}
 
 			if (typeof(IEnumerable).IsAssignableFrom(type))

--- a/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
@@ -175,7 +175,9 @@ public class SearchApi : BaseApi
 		[FromQuery] Include<Episode> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchEpisodes(q, sortBy, filter, pagination, fields));
+		return SearchPage(
+			await _searchManager.SearchEpisodes(q, sortBy, filter, pagination, fields)
+		);
 	}
 
 	/// <summary>
@@ -202,6 +204,8 @@ public class SearchApi : BaseApi
 		[FromQuery] Include<Studio> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchStudios(q, sortBy, filter, pagination, fields));
+		return SearchPage(
+			await _searchManager.SearchStudios(q, sortBy, filter, pagination, fields)
+		);
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
@@ -44,7 +44,7 @@ public class SearchApi : BaseApi
 		_searchManager = searchManager;
 	}
 
-	// TODO: add filters and facets
+	// TODO: add facets
 
 	/// <summary>
 	/// Search collections
@@ -143,11 +143,12 @@ public class SearchApi : BaseApi
 	public async Task<SearchPage<ILibraryItem>> SearchItems(
 		[FromQuery] string? q,
 		[FromQuery] Sort<ILibraryItem> sortBy,
+		[FromQuery] Filter<ILibraryItem>? filter,
 		[FromQuery] SearchPagination pagination,
 		[FromQuery] Include<ILibraryItem> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchItems(q, sortBy, pagination, fields));
+		return SearchPage(await _searchManager.SearchItems(q, sortBy, filter, pagination, fields));
 	}
 
 	/// <summary>
@@ -169,11 +170,12 @@ public class SearchApi : BaseApi
 	public async Task<SearchPage<Episode>> SearchEpisodes(
 		[FromQuery] string? q,
 		[FromQuery] Sort<Episode> sortBy,
+		[FromQuery] Filter<Episode>? filter,
 		[FromQuery] SearchPagination pagination,
 		[FromQuery] Include<Episode> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchEpisodes(q, sortBy, pagination, fields));
+		return SearchPage(await _searchManager.SearchEpisodes(q, sortBy, filter, pagination, fields));
 	}
 
 	/// <summary>
@@ -195,10 +197,11 @@ public class SearchApi : BaseApi
 	public async Task<SearchPage<Studio>> SearchStudios(
 		[FromQuery] string? q,
 		[FromQuery] Sort<Studio> sortBy,
+		[FromQuery] Filter<Studio>? filter,
 		[FromQuery] SearchPagination pagination,
 		[FromQuery] Include<Studio> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchStudios(q, sortBy, pagination, fields));
+		return SearchPage(await _searchManager.SearchStudios(q, sortBy, filter, pagination, fields));
 	}
 }

--- a/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
@@ -70,7 +70,9 @@ public class SearchApi : BaseApi
 		[FromQuery] Include<Collection> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchCollections(q, sortBy, filter, pagination, fields));
+		return SearchPage(
+			await _searchManager.SearchCollections(q, sortBy, filter, pagination, fields)
+		);
 	}
 
 	/// <summary>

--- a/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
+++ b/back/src/Kyoo.Core/Views/Resources/SearchApi.cs
@@ -65,11 +65,12 @@ public class SearchApi : BaseApi
 	public async Task<SearchPage<Collection>> SearchCollections(
 		[FromQuery] string? q,
 		[FromQuery] Sort<Collection> sortBy,
+		[FromQuery] Filter<ILibraryItem>? filter,
 		[FromQuery] SearchPagination pagination,
 		[FromQuery] Include<Collection> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchCollections(q, sortBy, pagination, fields));
+		return SearchPage(await _searchManager.SearchCollections(q, sortBy, filter, pagination, fields));
 	}
 
 	/// <summary>
@@ -91,11 +92,12 @@ public class SearchApi : BaseApi
 	public async Task<SearchPage<Show>> SearchShows(
 		[FromQuery] string? q,
 		[FromQuery] Sort<Show> sortBy,
+		[FromQuery] Filter<ILibraryItem>? filter,
 		[FromQuery] SearchPagination pagination,
 		[FromQuery] Include<Show> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchShows(q, sortBy, pagination, fields));
+		return SearchPage(await _searchManager.SearchShows(q, sortBy, filter, pagination, fields));
 	}
 
 	/// <summary>
@@ -117,11 +119,12 @@ public class SearchApi : BaseApi
 	public async Task<SearchPage<Movie>> SearchMovies(
 		[FromQuery] string? q,
 		[FromQuery] Sort<Movie> sortBy,
+		[FromQuery] Filter<ILibraryItem>? filter,
 		[FromQuery] SearchPagination pagination,
 		[FromQuery] Include<Movie> fields
 	)
 	{
-		return SearchPage(await _searchManager.SearchMovies(q, sortBy, pagination, fields));
+		return SearchPage(await _searchManager.SearchMovies(q, sortBy, filter, pagination, fields));
 	}
 
 	/// <summary>

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -39,7 +39,7 @@ internal static class FilterExtensionMethods
 		return value switch
 		{
 			null => null,
-			string s => s.Any(char.IsWhiteSpace) ? $"\"{s}\"" : s,
+			string s => s.Any(char.IsWhiteSpace) ? $"\\\"{s}\\\"" : s,
 			DateTimeOffset dateTime => dateTime.ToUnixTimeSeconds(),
 			DateOnly date => date.ToUnixTimeSeconds(),
 			_ => value

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -1,10 +1,11 @@
+using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using Kyoo.Abstractions.Models.Utils;
 using static System.Text.Json.JsonNamingPolicy;
 
 namespace Kyoo.Meiliseach;
 
-public static class FilterExtensionMethods
+internal static class FilterExtensionMethods
 {
 	public static string? CreateMeilisearchFilter<T>(this Filter<T>? filter)
 	{
@@ -14,17 +15,48 @@ public static class FilterExtensionMethods
 				=> $"({and.First.CreateMeilisearchFilter()}) AND ({and.Second.CreateMeilisearchFilter()})",
 			Filter<T>.Or or
 				=> $"({or.First.CreateMeilisearchFilter()}) OR ({or.Second.CreateMeilisearchFilter()})",
-			Filter<T>.Gt gt => $"{CamelCase.ConvertName(gt.Property)} > '{gt.Value}'",
-			Filter<T>.Lt lt => $"{CamelCase.ConvertName(lt.Property)} < '{lt.Value}'",
-			Filter<T>.Ge ge => $"{CamelCase.ConvertName(ge.Property)} >= '{ge.Value}'",
-			Filter<T>.Le le => $"{CamelCase.ConvertName(le.Property)} <= '{le.Value}'",
-			Filter<T>.Eq eq => $"{CamelCase.ConvertName(eq.Property)} = '{eq.Value}'",
-			Filter<T>.Has has => $"{CamelCase.ConvertName(has.Property)} = '{has.Value}'",
-			Filter<T>.Ne ne => $"{CamelCase.ConvertName(ne.Property)} != '{ne.Value}'",
+			Filter<T>.Gt gt => $"{CamelCase.ConvertName(gt.Property)} > {gt.Value.InMeilsearchFilterFormat()}",
+			Filter<T>.Lt lt => $"{CamelCase.ConvertName(lt.Property)} < {lt.Value.InMeilsearchFilterFormat()}",
+			Filter<T>.Ge ge => $"{CamelCase.ConvertName(ge.Property)} >= {ge.Value.InMeilsearchFilterFormat()}",
+			Filter<T>.Le le => $"{CamelCase.ConvertName(le.Property)} <= {le.Value.InMeilsearchFilterFormat()}",
+			Filter<T>.Eq eq => $"{CamelCase.ConvertName(eq.Property)} = {eq.Value.InMeilsearchFilterFormat()}",
+			Filter<T>.Has has => $"{CamelCase.ConvertName(has.Property)} = {has.Value.InMeilsearchFilterFormat()}",
+			Filter<T>.Ne ne => $"{CamelCase.ConvertName(ne.Property)} != {ne.Value.InMeilsearchFilterFormat()}",
 			Filter<T>.Not not => $"NOT ({not.Filter.CreateMeilisearchFilter()})",
 			Filter<T>.CmpRandom
 				=> throw new ValidationException("Random comparison is not supported."),
 			_ => null
 		};
+	}
+
+	private static object? InMeilsearchFilterFormat(this object? value)
+	{
+		return value switch
+		{
+			null => null,
+			string s => s.Any(char.IsWhiteSpace) ? $"\"{s}\"" : s,
+			DateTimeOffset dateTime => dateTime.ToUnixTimeSeconds(),
+			DateOnly date => date.ToUnixTimeSeconds(),
+			_ => value
+		};
+	}
+
+	public static object? InMeilisearchFormat(this object? value)
+	{
+		return value switch
+		{
+			null => null,
+			string => value,
+			Enum => value.ToString(),
+			IEnumerable enumerable => enumerable.Cast<object>().Select(InMeilisearchFormat).ToArray(),
+			DateTimeOffset dateTime => dateTime.ToUnixTimeSeconds(),
+			DateOnly date => date.ToUnixTimeSeconds(),
+			_ => value
+		};
+	}
+
+	private static long ToUnixTimeSeconds(this DateOnly date)
+	{
+		return new DateTimeOffset(date.ToDateTime(new TimeOnly())).ToUnixTimeSeconds();
 	}
 }

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -31,7 +31,7 @@ internal static class FilterExtensionMethods
 
 	private static string CreateBasicFilterString(string property, string @operator, object? value)
 	{
-		return $"{CamelCase.ConvertName(property)} {@operator} {value.InMeilisearchFormat()}";
+		return $"{CamelCase.ConvertName(property)} {@operator} {value.InMeilsearchFilterFormat()}";
 	}
 
 	private static object? InMeilsearchFilterFormat(this object? value)

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -53,7 +53,8 @@ internal static class FilterExtensionMethods
 			null => null,
 			string => value,
 			Enum => value.ToString(),
-			IEnumerable enumerable => enumerable.Cast<object>().Select(InMeilisearchFormat).ToArray(),
+			IEnumerable enumerable
+				=> enumerable.Cast<object>().Select(InMeilisearchFormat).ToArray(),
 			DateTimeOffset dateTime => dateTime.ToUnixTimeSeconds(),
 			DateOnly date => date.ToUnixTimeSeconds(),
 			_ => value

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using Kyoo.Abstractions.Models.Utils;
 using static System.Text.Json.JsonNamingPolicy;
@@ -46,22 +45,7 @@ internal static class FilterExtensionMethods
 		};
 	}
 
-	public static object? InMeilisearchFormat(this object? value)
-	{
-		return value switch
-		{
-			null => null,
-			string => value,
-			Enum => value.ToString(),
-			IEnumerable enumerable
-				=> enumerable.Cast<object>().Select(InMeilisearchFormat).ToArray(),
-			DateTimeOffset dateTime => dateTime.ToUnixTimeSeconds(),
-			DateOnly date => date.ToUnixTimeSeconds(),
-			_ => value
-		};
-	}
-
-	private static long ToUnixTimeSeconds(this DateOnly date)
+	public static long ToUnixTimeSeconds(this DateOnly date)
 	{
 		return new DateTimeOffset(date.ToDateTime(new TimeOnly())).ToUnixTimeSeconds();
 	}

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -9,8 +9,10 @@ public static class FilterExtensionMethods
 	{
 		return filter switch
 		{
-			Filter<T>.And and => $"({and.First.CreateMeilisearchFilter()}) AND ({and.Second.CreateMeilisearchFilter()})",
-			Filter<T>.Or or => $"({or.First.CreateMeilisearchFilter()}) OR ({or.Second.CreateMeilisearchFilter()})",
+			Filter<T>.And and
+				=> $"({and.First.CreateMeilisearchFilter()}) AND ({and.Second.CreateMeilisearchFilter()})",
+			Filter<T>.Or or
+				=> $"({or.First.CreateMeilisearchFilter()}) OR ({or.Second.CreateMeilisearchFilter()})",
 			Filter<T>.Gt gt => $"{gt.Property} > {gt.Value}",
 			Filter<T>.Lt lt => $"{lt.Property} < {lt.Value}",
 			Filter<T>.Ge ge => $"{ge.Property} >= {ge.Value}",
@@ -19,7 +21,8 @@ public static class FilterExtensionMethods
 			Filter<T>.Has has => $"{has.Property} = {has.Value}",
 			Filter<T>.Ne ne => $"{ne.Property} != {ne.Value}",
 			Filter<T>.Not not => $"NOT ({not.Filter.CreateMeilisearchFilter()})",
-			Filter<T>.CmpRandom => throw new ValidationException("Random comparison is not supported."),
+			Filter<T>.CmpRandom
+				=> throw new ValidationException("Random comparison is not supported."),
 			_ => null
 		};
 	}

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Kyoo.Abstractions.Models.Utils;
+using static System.Text.Json.JsonNamingPolicy;
 
 namespace Kyoo.Meiliseach;
 
@@ -13,13 +14,13 @@ public static class FilterExtensionMethods
 				=> $"({and.First.CreateMeilisearchFilter()}) AND ({and.Second.CreateMeilisearchFilter()})",
 			Filter<T>.Or or
 				=> $"({or.First.CreateMeilisearchFilter()}) OR ({or.Second.CreateMeilisearchFilter()})",
-			Filter<T>.Gt gt => $"{gt.Property} > {gt.Value}",
-			Filter<T>.Lt lt => $"{lt.Property} < {lt.Value}",
-			Filter<T>.Ge ge => $"{ge.Property} >= {ge.Value}",
-			Filter<T>.Le le => $"{le.Property} <= {le.Value}",
-			Filter<T>.Eq eq => $"{eq.Property} = {eq.Value}",
-			Filter<T>.Has has => $"{has.Property} = {has.Value}",
-			Filter<T>.Ne ne => $"{ne.Property} != {ne.Value}",
+			Filter<T>.Gt gt => $"{CamelCase.ConvertName(gt.Property)} > '{gt.Value}'",
+			Filter<T>.Lt lt => $"{CamelCase.ConvertName(lt.Property)} < '{lt.Value}'",
+			Filter<T>.Ge ge => $"{CamelCase.ConvertName(ge.Property)} >= '{ge.Value}'",
+			Filter<T>.Le le => $"{CamelCase.ConvertName(le.Property)} <= '{le.Value}'",
+			Filter<T>.Eq eq => $"{CamelCase.ConvertName(eq.Property)} = '{eq.Value}'",
+			Filter<T>.Has has => $"{CamelCase.ConvertName(has.Property)} = '{has.Value}'",
+			Filter<T>.Ne ne => $"{CamelCase.ConvertName(ne.Property)} != '{ne.Value}'",
 			Filter<T>.Not not => $"NOT ({not.Filter.CreateMeilisearchFilter()})",
 			Filter<T>.CmpRandom
 				=> throw new ValidationException("Random comparison is not supported."),

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -38,7 +38,7 @@ internal static class FilterExtensionMethods
 		return value switch
 		{
 			null => null,
-			string s => s.Any(char.IsWhiteSpace) ? $"\\\"{s}\\\"" : s,
+			string s => s.Any(char.IsWhiteSpace) ? $"\"{s.Replace("\"", "\\\"")}\"" : s,
 			DateTimeOffset dateTime => dateTime.ToUnixTimeSeconds(),
 			DateOnly date => date.ToUnixTimeSeconds(),
 			_ => value

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using Kyoo.Abstractions.Models.Utils;
+
+namespace Kyoo.Meiliseach;
+
+public static class FilterExtensionMethods
+{
+	public static string? CreateMeilisearchFilter<T>(this Filter<T>? filter)
+	{
+		return filter switch
+		{
+			Filter<T>.And and => $"({and.First.CreateMeilisearchFilter()}) AND ({and.Second.CreateMeilisearchFilter()})",
+			Filter<T>.Or or => $"({or.First.CreateMeilisearchFilter()}) OR ({or.Second.CreateMeilisearchFilter()})",
+			Filter<T>.Gt gt => $"{gt.Property} > {gt.Value}",
+			Filter<T>.Lt lt => $"{lt.Property} < {lt.Value}",
+			Filter<T>.Ge ge => $"{ge.Property} >= {ge.Value}",
+			Filter<T>.Le le => $"{le.Property} <= {le.Value}",
+			Filter<T>.Eq eq => $"{eq.Property} = {eq.Value}",
+			Filter<T>.Has has => $"{has.Property} = {has.Value}",
+			Filter<T>.Ne ne => $"{ne.Property} != {ne.Value}",
+			Filter<T>.Not not => $"NOT ({not.Filter.CreateMeilisearchFilter()})",
+			Filter<T>.CmpRandom => throw new ValidationException("Random comparison is not supported."),
+			_ => null
+		};
+	}
+}

--- a/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
+++ b/back/src/Kyoo.Meilisearch/FilterExtensionMethods.cs
@@ -15,18 +15,23 @@ internal static class FilterExtensionMethods
 				=> $"({and.First.CreateMeilisearchFilter()}) AND ({and.Second.CreateMeilisearchFilter()})",
 			Filter<T>.Or or
 				=> $"({or.First.CreateMeilisearchFilter()}) OR ({or.Second.CreateMeilisearchFilter()})",
-			Filter<T>.Gt gt => $"{CamelCase.ConvertName(gt.Property)} > {gt.Value.InMeilsearchFilterFormat()}",
-			Filter<T>.Lt lt => $"{CamelCase.ConvertName(lt.Property)} < {lt.Value.InMeilsearchFilterFormat()}",
-			Filter<T>.Ge ge => $"{CamelCase.ConvertName(ge.Property)} >= {ge.Value.InMeilsearchFilterFormat()}",
-			Filter<T>.Le le => $"{CamelCase.ConvertName(le.Property)} <= {le.Value.InMeilsearchFilterFormat()}",
-			Filter<T>.Eq eq => $"{CamelCase.ConvertName(eq.Property)} = {eq.Value.InMeilsearchFilterFormat()}",
-			Filter<T>.Has has => $"{CamelCase.ConvertName(has.Property)} = {has.Value.InMeilsearchFilterFormat()}",
-			Filter<T>.Ne ne => $"{CamelCase.ConvertName(ne.Property)} != {ne.Value.InMeilsearchFilterFormat()}",
+			Filter<T>.Gt gt => CreateBasicFilterString(gt.Property, ">", gt.Value),
+			Filter<T>.Lt lt => CreateBasicFilterString(lt.Property, "<", lt.Value),
+			Filter<T>.Ge ge => CreateBasicFilterString(ge.Property, ">=", ge.Value),
+			Filter<T>.Le le => CreateBasicFilterString(le.Property, "<=", le.Value),
+			Filter<T>.Eq eq => CreateBasicFilterString(eq.Property, "=", eq.Value),
+			Filter<T>.Has has => CreateBasicFilterString(has.Property, "=", has.Value),
+			Filter<T>.Ne ne => CreateBasicFilterString(ne.Property, "!=", ne.Value),
 			Filter<T>.Not not => $"NOT ({not.Filter.CreateMeilisearchFilter()})",
 			Filter<T>.CmpRandom
 				=> throw new ValidationException("Random comparison is not supported."),
 			_ => null
 		};
+	}
+
+	private static string CreateBasicFilterString(string property, string @operator, object? value)
+	{
+		return $"{CamelCase.ConvertName(property)} {@operator} {value.InMeilisearchFormat()}";
 	}
 
 	private static object? InMeilsearchFilterFormat(this object? value)

--- a/back/src/Kyoo.Meilisearch/MeiliSync.cs
+++ b/back/src/Kyoo.Meilisearch/MeiliSync.cs
@@ -60,7 +60,10 @@ public class MeiliSync
 			var dictionary = (IDictionary<string, object?>)expando;
 
 			foreach (PropertyInfo property in item.GetType().GetProperties())
-				dictionary.Add(CamelCase.ConvertName(property.Name), property.GetValue(item).InMeilisearchFormat());
+				dictionary.Add(
+					CamelCase.ConvertName(property.Name),
+					property.GetValue(item).InMeilisearchFormat()
+				);
 			dictionary.Add("ref", $"{kind}-{item.Id}");
 			expando.kind = kind;
 			return _client.Index(index).AddDocumentsAsync(new[] { expando });

--- a/back/src/Kyoo.Meilisearch/MeiliSync.cs
+++ b/back/src/Kyoo.Meilisearch/MeiliSync.cs
@@ -95,4 +95,18 @@ public class MeiliSync
 			_ => value
 		};
 	}
+
+	public async Task SyncEverything(ILibraryManager database)
+	{
+		foreach (Movie movie in await database.Movies.GetAll(limit: 0))
+			await CreateOrUpdate("items", movie, nameof(Movie));
+		foreach (Show show in await database.Shows.GetAll(limit: 0))
+			await CreateOrUpdate("items", show, nameof(Show));
+		foreach (Collection collection in await database.Collections.GetAll(limit: 0))
+			await CreateOrUpdate("items", collection, nameof(Collection));
+		foreach (Episode episode in await database.Episodes.GetAll(limit: 0))
+			await CreateOrUpdate(nameof(Episode), episode);
+		foreach (Studio studio in await database.Studios.GetAll(limit: 0))
+			await CreateOrUpdate(nameof(Studio), studio);
+	}
 }

--- a/back/src/Kyoo.Meilisearch/MeiliSync.cs
+++ b/back/src/Kyoo.Meilisearch/MeiliSync.cs
@@ -60,7 +60,7 @@ public class MeiliSync
 			var dictionary = (IDictionary<string, object?>)expando;
 
 			foreach (PropertyInfo property in item.GetType().GetProperties())
-				dictionary.Add(CamelCase.ConvertName(property.Name), property.GetValue(item));
+				dictionary.Add(CamelCase.ConvertName(property.Name), property.GetValue(item).InMeilisearchFormat());
 			dictionary.Add("ref", $"{kind}-{item.Id}");
 			expando.kind = kind;
 			return _client.Index(index).AddDocumentsAsync(new[] { expando });

--- a/back/src/Kyoo.Meilisearch/MeilisearchModule.cs
+++ b/back/src/Kyoo.Meilisearch/MeilisearchModule.cs
@@ -119,11 +119,6 @@ public static class MeilisearchModule
 			},
 		};
 
-	/// <summary>
-	/// Init meilisearch indexes.
-	/// </summary>
-	/// <param name="provider">The service list to retrieve the meilisearch client</param>
-	/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 	public static async Task Initialize(IServiceProvider provider)
 	{
 		MeilisearchClient client = provider.GetRequiredService<MeilisearchClient>();
@@ -131,6 +126,13 @@ public static class MeilisearchModule
 		await _CreateIndex(client, "items", true);
 		await _CreateIndex(client, nameof(Episode), false);
 		await _CreateIndex(client, nameof(Studio), false);
+	}
+
+	public static async Task SyncDatabase(IServiceProvider provider)
+	{
+		await using AsyncServiceScope scope = provider.CreateAsyncScope();
+		ILibraryManager database = scope.ServiceProvider.GetRequiredService<ILibraryManager>();
+		await scope.ServiceProvider.GetRequiredService<MeiliSync>().SyncEverything(database);
 	}
 
 	private static async Task _CreateIndex(MeilisearchClient client, string index, bool hasKind)

--- a/back/src/Kyoo.Meilisearch/MeilisearchModule.cs
+++ b/back/src/Kyoo.Meilisearch/MeilisearchModule.cs
@@ -49,6 +49,8 @@ public static class MeilisearchModule
 						CamelCase.ConvertName(nameof(Movie.Genres)),
 						CamelCase.ConvertName(nameof(Movie.Status)),
 						CamelCase.ConvertName(nameof(Movie.AirDate)),
+						CamelCase.ConvertName(nameof(Show.StartAir)),
+						CamelCase.ConvertName(nameof(Show.EndAir)),
 						CamelCase.ConvertName(nameof(Movie.StudioId)),
 						"kind"
 					},

--- a/back/src/Kyoo.Meilisearch/SearchManager.cs
+++ b/back/src/Kyoo.Meilisearch/SearchManager.cs
@@ -104,7 +104,14 @@ public class SearchManager : ISearchManager
 		Include<ILibraryItem>? include = default
 	)
 	{
-		return _Search("items", query, filter.CreateMeilisearchFilter(), sortBy, pagination, include);
+		return _Search(
+			"items",
+			query,
+			filter.CreateMeilisearchFilter(),
+			sortBy,
+			pagination,
+			include
+		);
 	}
 
 	/// <inheritdoc/>
@@ -149,7 +156,14 @@ public class SearchManager : ISearchManager
 		Include<Episode>? include = default
 	)
 	{
-		return _Search(nameof(Episode), query, filter.CreateMeilisearchFilter(), sortBy, pagination, include);
+		return _Search(
+			nameof(Episode),
+			query,
+			filter.CreateMeilisearchFilter(),
+			sortBy,
+			pagination,
+			include
+		);
 	}
 
 	/// <inheritdoc/>
@@ -161,7 +175,14 @@ public class SearchManager : ISearchManager
 		Include<Studio>? include = default
 	)
 	{
-		return _Search(nameof(Studio), query, filter.CreateMeilisearchFilter(), sortBy, pagination, include);
+		return _Search(
+			nameof(Studio),
+			query,
+			filter.CreateMeilisearchFilter(),
+			sortBy,
+			pagination,
+			include
+		);
 	}
 
 	private class IdResource

--- a/back/src/Kyoo.Meilisearch/SearchManager.cs
+++ b/back/src/Kyoo.Meilisearch/SearchManager.cs
@@ -118,33 +118,36 @@ public class SearchManager : ISearchManager
 	public Task<SearchPage<Movie>.SearchResult> SearchMovies(
 		string? query,
 		Sort<Movie> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<Movie>? include = default
 	)
 	{
-		return _Search("items", query, $"kind = {nameof(Movie)}", sortBy, pagination, include);
+		return _Search("items", query, _CreateMediaTypeFilter<Movie>(filter), sortBy, pagination, include);
 	}
 
 	/// <inheritdoc/>
 	public Task<SearchPage<Show>.SearchResult> SearchShows(
 		string? query,
 		Sort<Show> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<Show>? include = default
 	)
 	{
-		return _Search("items", query, $"kind = {nameof(Show)}", sortBy, pagination, include);
+		return _Search("items", query, _CreateMediaTypeFilter<Show>(filter), sortBy, pagination, include);
 	}
 
 	/// <inheritdoc/>
 	public Task<SearchPage<Collection>.SearchResult> SearchCollections(
 		string? query,
 		Sort<Collection> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<Collection>? include = default
 	)
 	{
-		return _Search("items", query, $"kind = {nameof(Collection)}", sortBy, pagination, include);
+		return _Search("items", query, _CreateMediaTypeFilter<Collection>(filter), sortBy, pagination, include);
 	}
 
 	/// <inheritdoc/>
@@ -183,6 +186,16 @@ public class SearchManager : ISearchManager
 			pagination,
 			include
 		);
+	}
+
+	private string _CreateMediaTypeFilter<T>(Filter<ILibraryItem>? filter) where T : ILibraryItem
+	{
+		string filterString = $"kind = {typeof(T).Name}";
+		if (filter is not null)
+		{
+			filterString += $" AND ({filter.CreateMeilisearchFilter()})";
+		}
+		return filterString;
 	}
 
 	private class IdResource

--- a/back/src/Kyoo.Meilisearch/SearchManager.cs
+++ b/back/src/Kyoo.Meilisearch/SearchManager.cs
@@ -123,7 +123,14 @@ public class SearchManager : ISearchManager
 		Include<Movie>? include = default
 	)
 	{
-		return _Search("items", query, _CreateMediaTypeFilter<Movie>(filter), sortBy, pagination, include);
+		return _Search(
+			"items",
+			query,
+			_CreateMediaTypeFilter<Movie>(filter),
+			sortBy,
+			pagination,
+			include
+		);
 	}
 
 	/// <inheritdoc/>
@@ -135,7 +142,14 @@ public class SearchManager : ISearchManager
 		Include<Show>? include = default
 	)
 	{
-		return _Search("items", query, _CreateMediaTypeFilter<Show>(filter), sortBy, pagination, include);
+		return _Search(
+			"items",
+			query,
+			_CreateMediaTypeFilter<Show>(filter),
+			sortBy,
+			pagination,
+			include
+		);
 	}
 
 	/// <inheritdoc/>
@@ -147,7 +161,14 @@ public class SearchManager : ISearchManager
 		Include<Collection>? include = default
 	)
 	{
-		return _Search("items", query, _CreateMediaTypeFilter<Collection>(filter), sortBy, pagination, include);
+		return _Search(
+			"items",
+			query,
+			_CreateMediaTypeFilter<Collection>(filter),
+			sortBy,
+			pagination,
+			include
+		);
 	}
 
 	/// <inheritdoc/>
@@ -188,7 +209,8 @@ public class SearchManager : ISearchManager
 		);
 	}
 
-	private string _CreateMediaTypeFilter<T>(Filter<ILibraryItem>? filter) where T : ILibraryItem
+	private string _CreateMediaTypeFilter<T>(Filter<ILibraryItem>? filter)
+		where T : ILibraryItem
 	{
 		string filterString = $"kind = {typeof(T).Name}";
 		if (filter is not null)

--- a/back/src/Kyoo.Meilisearch/SearchManager.cs
+++ b/back/src/Kyoo.Meilisearch/SearchManager.cs
@@ -99,11 +99,12 @@ public class SearchManager : ISearchManager
 	public Task<SearchPage<ILibraryItem>.SearchResult> SearchItems(
 		string? query,
 		Sort<ILibraryItem> sortBy,
+		Filter<ILibraryItem>? filter,
 		SearchPagination pagination,
 		Include<ILibraryItem>? include = default
 	)
 	{
-		return _Search("items", query, null, sortBy, pagination, include);
+		return _Search("items", query, filter.CreateMeilisearchFilter(), sortBy, pagination, include);
 	}
 
 	/// <inheritdoc/>
@@ -143,22 +144,24 @@ public class SearchManager : ISearchManager
 	public Task<SearchPage<Episode>.SearchResult> SearchEpisodes(
 		string? query,
 		Sort<Episode> sortBy,
+		Filter<Episode>? filter,
 		SearchPagination pagination,
 		Include<Episode>? include = default
 	)
 	{
-		return _Search(nameof(Episode), query, null, sortBy, pagination, include);
+		return _Search(nameof(Episode), query, filter.CreateMeilisearchFilter(), sortBy, pagination, include);
 	}
 
 	/// <inheritdoc/>
 	public Task<SearchPage<Studio>.SearchResult> SearchStudios(
 		string? query,
 		Sort<Studio> sortBy,
+		Filter<Studio>? filter,
 		SearchPagination pagination,
 		Include<Studio>? include = default
 	)
 	{
-		return _Search(nameof(Studio), query, null, sortBy, pagination, include);
+		return _Search(nameof(Studio), query, filter.CreateMeilisearchFilter(), sortBy, pagination, include);
 	}
 
 	private class IdResource


### PR DESCRIPTION
Required if we want to seamlessly add filtering to the browse page. Otherwise filtering won't work when users use the Search bar.

I've now tested this and it seems to work with enums (`genres`) and dates (`airDate`, `startAir`, `endAir`).