### PR TITLE
 Switch from mediainfo to ffprobe 

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -32,7 +32,6 @@ in
       go
       wgo
       mediainfo
-      libmediainfo
       ffmpeg-full
       postgresql_15
       pgformatter

--- a/transcoder/Dockerfile
+++ b/transcoder/Dockerfile
@@ -20,7 +20,7 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 RUN update-ca-certificates
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
-	ffmpeg libavformat-dev libavutil-dev libswscale-dev libmediainfo-dev \
+	ffmpeg libavformat-dev libavutil-dev libswscale-dev \
 	&& apt-get clean autoclean -y \
 	&& apt-get autoremove -y
 WORKDIR /app
@@ -42,7 +42,7 @@ RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.s
 RUN set -x && apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 	# runtime dependencies
-	ffmpeg libmediainfo-dev \
+	ffmpeg \
 	# hwaccel dependencies
 	vainfo mesa-va-drivers \
 	# intel hwaccel dependencies, not available everywhere

--- a/transcoder/Dockerfile.dev
+++ b/transcoder/Dockerfile.dev
@@ -31,9 +31,9 @@ RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list.d/debian.s
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 	# runtime dependencies
-	ffmpeg libavformat-dev \
+	ffmpeg \
 	# build dependencies
-	libavutil-dev libswscale-dev libmediainfo-dev \
+	libavformat-dev libavutil-dev libswscale-dev \
 	# hwaccel dependencies
 	vainfo mesa-va-drivers \
 	# intel hwaccel dependencies, not available everywhere

--- a/transcoder/go.mod
+++ b/transcoder/go.mod
@@ -12,13 +12,12 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
-	github.com/zoriya/go-mediainfo v0.0.0-20240113011752-07018f07efae
 	gitlab.com/opennota/screengen v1.0.2
 	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/image v0.10.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
+	gopkg.in/vansante/go-ffprobe.v2 v2.2.0
 )
-
-require golang.org/x/image v0.10.0 // indirect

--- a/transcoder/go.sum
+++ b/transcoder/go.sum
@@ -22,8 +22,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zoriya/go-mediainfo v0.0.0-20240113011752-07018f07efae h1:Xmtcb/GrG1jcLxC3cDFwdAM1oV7fLNBcN3h3YL+gN6g=
-github.com/zoriya/go-mediainfo v0.0.0-20240113011752-07018f07efae/go.mod h1:jzun1oQGoJSh65g1XKaolTmjd6HW/34WHH7VMdJdbvM=
 gitlab.com/opennota/screengen v1.0.2 h1:GxYTJdAPEzmg5v5CV4dgn45JVW+EcXXAvCxhE7w6UDw=
 gitlab.com/opennota/screengen v1.0.2/go.mod h1:4kED4yriw2zslwYmXFCa5qCvEKwleBA7l5OE+d94NTU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -71,5 +69,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/vansante/go-ffprobe.v2 v2.2.0 h1:iuOqTsbfYuqIz4tAU9NWh22CmBGxlGHdgj4iqP+NUmY=
+gopkg.in/vansante/go-ffprobe.v2 v2.2.0/go.mod h1:qF0AlAjk7Nqzqf3y333Ly+KxN3cKF2JqA3JT5ZheUGE=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/transcoder/src/codec.go
+++ b/transcoder/src/codec.go
@@ -1,12 +1,11 @@
 package src
 
 import (
-	"cmp"
 	"fmt"
 	"log"
 	"strings"
 
-	"github.com/zoriya/go-mediainfo"
+	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
 // convert mediainfo to RFC 6381, waiting for either of those tickets to be resolved:
@@ -15,19 +14,13 @@ import (
 //	https://trac.ffmpeg.org/ticket/6617
 //
 // this code is addapted from https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Api/Helpers/HlsCodecStringHelpers.cs
-func GetMimeCodec(mi *mediainfo.File, kind mediainfo.StreamKind, i int) *string {
-	codec := cmp.Or(
-		mi.Parameter(kind, i, "InternetMediaType"),
-		mi.Parameter(kind, i, "Format"),
-	)
-
-	switch codec {
-	case "video/H264", "AVC":
+// and https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/HEAD%3a/libavformat/hlsenc.c#l344
+func GetMimeCodec(stream *ffprobe.Stream) *string {
+	switch stream.CodecName {
+	case "h264":
 		ret := "avc1"
-		info := strings.Split(strings.ToLower(mi.Parameter(kind, i, "Format_Profile")), "@")
 
-		format := info[0]
-		switch format {
+		switch strings.ToLower(stream.Profile) {
 		case "high":
 			ret += ".6400"
 		case "main":
@@ -39,37 +32,30 @@ func GetMimeCodec(mi *mediainfo.File, kind mediainfo.StreamKind, i int) *string 
 			ret += ".4240"
 		}
 
-		// level format is l3.1 for level 31
-		level := ParseFloat(info[1][1:])
-		ret += fmt.Sprintf("%02x", int(level*10))
+		ret += fmt.Sprintf("%02x", stream.Level)
 		return &ret
 
-	case "video/H265", "HEVC":
+	case "h265":
 		// The h265 syntax is a bit of a mystery at the time this comment was written.
 		// This is what I've found through various sources:
 		// FORMAT: [codecTag].[profile].[constraint?].L[level * 30].[UNKNOWN]
 		ret := "hvc1"
-		info := strings.Split(strings.ToLower(mi.Parameter(kind, i, "Format_Profile")), "@")
 
-		profile := info[0]
-		if profile == "main 10" {
+		if stream.Profile == "main 10" {
 			ret += ".2.4"
 		} else {
 			ret += ".1.4"
 		}
 
-		level := ParseFloat(info[1][:1])
-		ret += fmt.Sprintf(".L%02X.BO", int(level*30))
+		ret += fmt.Sprintf(".L%02X.BO", stream.Level)
 		return &ret
 
-	case "AV1":
+	case "av1":
 		// https://aomedia.org/av1/specification/annex-a/
 		// FORMAT: [codecTag].[profile].[level][tier].[bitDepth]
 		ret := "av01"
-		info := strings.Split(strings.ToLower(mi.Parameter(kind, i, "Format_Profile")), "@")
 
-		profile := info[0]
-		switch profile {
+		switch strings.ToLower(stream.Profile) {
 		case "main":
 			ret += ".0"
 		case "high":
@@ -77,30 +63,24 @@ func GetMimeCodec(mi *mediainfo.File, kind mediainfo.StreamKind, i int) *string 
 		case "professional":
 			ret += ".2"
 		default:
-			// Default to Main
-			ret += ".0"
 		}
 
-		// level is not defined in mediainfo. using a default
-		// Default to the maximum defined level 6.3
-		level := 19
-
-		bitdepth := ParseUint(mi.Parameter(kind, i, "BitDepth"))
+		// not sure about this field, we want pixel bit depth
+		bitdepth := ParseUint(stream.BitsPerRawSample)
 		if bitdepth != 8 && bitdepth != 10 && bitdepth != 12 {
 			// Default to 8 bits
 			bitdepth = 8
 		}
 
 		tierflag := 'M'
-		ret += fmt.Sprintf(".%02X%c.%02d", level, tierflag, bitdepth)
+		ret += fmt.Sprintf(".%02X%c.%02d", stream.Level, tierflag, bitdepth)
 
 		return &ret
 
-	case "AAC":
+	case "aac":
 		ret := "mp4a"
 
-		profile := strings.ToLower(mi.Parameter(kind, i, "Format_AdditionalFeatures"))
-		switch profile {
+		switch strings.ToLower(stream.Profile) {
 		case "he":
 			ret += ".40.5"
 		case "lc":
@@ -111,24 +91,24 @@ func GetMimeCodec(mi *mediainfo.File, kind mediainfo.StreamKind, i int) *string 
 
 		return &ret
 
-	case "audio/opus", "Opus":
+	case "opus":
 		ret := "Opus"
 		return &ret
 
-	case "AC-3":
+	case "ac-3":
 		ret := "mp4a.a5"
 		return &ret
 
-	case "audio/eac3", "E-AC-3":
+	case "eac3", "E-AC-3":
 		ret := "mp4a.a6"
 		return &ret
 
-	case "audio/x-flac", "FLAC":
+	case "x-flac", "FLAC":
 		ret := "fLaC"
 		return &ret
 
 	default:
-		log.Printf("No known mime format for: %s", codec)
+		log.Printf("No known mime format for: %s", stream.CodecName)
 		return nil
 	}
 }

--- a/transcoder/src/codec.go
+++ b/transcoder/src/codec.go
@@ -35,7 +35,7 @@ func GetMimeCodec(stream *ffprobe.Stream) *string {
 		ret += fmt.Sprintf("%02x", stream.Level)
 		return &ret
 
-	case "h265":
+	case "h265", "hevc":
 		// The h265 syntax is a bit of a mystery at the time this comment was written.
 		// This is what I've found through various sources:
 		// FORMAT: [codecTag].[profile].[constraint?].L[level * 30].[UNKNOWN]
@@ -95,15 +95,15 @@ func GetMimeCodec(stream *ffprobe.Stream) *string {
 		ret := "Opus"
 		return &ret
 
-	case "ac-3":
+	case "ac3":
 		ret := "mp4a.a5"
 		return &ret
 
-	case "eac3", "E-AC-3":
+	case "eac3":
 		ret := "mp4a.a6"
 		return &ret
 
-	case "x-flac", "FLAC":
+	case "flac":
 		ret := "fLaC"
 		return &ret
 

--- a/transcoder/src/info.go
+++ b/transcoder/src/info.go
@@ -248,7 +248,7 @@ func saveInfo[T any](save_path string, mi *T) error {
 func getInfo(path string) (*MediaInfo, error) {
 	defer printExecTime("mediainfo for %s", path)()
 
-	ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 
 	mi, err := ffprobe.ProbeURL(ctx, path)

--- a/transcoder/src/info.go
+++ b/transcoder/src/info.go
@@ -189,8 +189,10 @@ func GetInfo(path string, sha string) (*MediaInfo, error) {
 
 			var val *MediaInfo
 			val, err = getInfo(path)
-			*mi.info = *val
-			mi.info.Sha = sha
+			if err == nil {
+				*mi.info = *val
+				mi.info.Sha = sha
+			}
 			mi.ready.Done()
 			saveInfo(save_path, mi.info)
 		}()

--- a/transcoder/src/settings.go
+++ b/transcoder/src/settings.go
@@ -14,6 +14,7 @@ type SettingsT struct {
 	Outpath     string
 	Metadata    string
 	RoutePrefix string
+	SafePath    string
 	HwAccel     HwAccelT
 }
 
@@ -28,5 +29,6 @@ var Settings = SettingsT{
 	Outpath:     GetEnvOr("GOCODER_CACHE_ROOT", "/cache"),
 	Metadata:    GetEnvOr("GOCODER_METADATA_ROOT", "/metadata"),
 	RoutePrefix: GetEnvOr("GOCODER_PREFIX", ""),
+	SafePath:    GetEnvOr("GOCODER_SAFE_PATH", "/video"),
 	HwAccel:     DetectHardwareAccel(),
 }

--- a/transcoder/utils.go
+++ b/transcoder/utils.go
@@ -14,8 +14,6 @@ import (
 	"github.com/zoriya/kyoo/transcoder/src"
 )
 
-var safe_path = src.GetEnvOr("GOCODER_SAFE_PATH", "/video")
-
 // Encode the version in the hash path to update cached values.
 // Older versions won't be deleted (needed to allow multiples versions of the transcoder to run at the same time)
 // If the version changes a lot, we might want to automatically delete older versions.
@@ -34,7 +32,7 @@ func GetPath(c echo.Context) (string, string, error) {
 	if !filepath.IsAbs(path) {
 		return "", "", echo.NewHTTPError(http.StatusBadRequest, "Absolute path required.")
 	}
-	if !strings.HasPrefix(path, safe_path) {
+	if !strings.HasPrefix(path, src.Settings.SafePath) {
 		return "", "", echo.NewHTTPError(http.StatusBadRequest, "Selected path is not marked as safe.")
 	}
 	hash, err := getHash(path)


### PR DESCRIPTION
Missing steps:
- ~~Convert language from ISO-639-2 to IETF BCP 47 (mediainfo used to do this for us)~~
- ~~Cope with https://trac.ffmpeg.org/ticket/3392 (ffprobe does not report bitrate with h264 inside an mkv)~~
- ~~Check that RFC-6381 handling is right for all codecs~~
- ~~Re-enable mediainfo caching (disabled for testing)~~

Motivation for this change:
Mediainfo has a flunky handling of utf8 strings so having a filename (or metadata) not in ascii could lead to issue.