### PR TITLE
EpisodeLine: Add missing border radius

### DIFF
--- a/front/packages/ui/src/details/episode.tsx
+++ b/front/packages/ui/src/details/episode.tsx
@@ -259,7 +259,7 @@ export const EpisodeLine = ({
 					width: percent(18),
 					aspectRatio: 16 / 9,
 				}}
-				{...css({ flexShrink: 0, m: ts(1) })}
+				{...css({ flexShrink: 0, m: ts(1), borderRadius: imageBorderRadius })}
 			>
 				{(watchedPercent || watchedStatus === WatchStatusV.Completed) && (
 					<>


### PR DESCRIPTION
Before:
<img width="428" alt="Screenshot 2024-07-07 at 12 15 24" src="https://github.com/zoriya/Kyoo/assets/60505370/d07baa27-4ec1-48b6-acfd-5173d4612530">

After:
<img width="428" alt="Screenshot 2024-07-07 at 12 15 02" src="https://github.com/zoriya/Kyoo/assets/60505370/2e8bb70d-8393-4650-a21a-6dbc47ee4c45">
