### PR TITLE
Front: Fix Media Metadata

### DIFF
--- a/front/packages/ui/src/player/index.tsx
+++ b/front/packages/ui/src/player/index.tsx
@@ -81,6 +81,10 @@ export const Player = ({
 	const [playbackError, setPlaybackError] = useState<string | undefined>(undefined);
 	const { data, error } = useFetch(Player.query(type, slug));
 	const { data: info, error: infoError } = useFetch(Player.infoQuery(type, slug));
+	const image =
+		data && data.type === "episode"
+			? data.show?.poster ?? data?.thumbnail
+			: data?.thumbnail;
 	const previous =
 		data && data.type === "episode" && data.previousEpisode
 			? `/watch/${data.previousEpisode.slug}?t=0`
@@ -142,7 +146,7 @@ export const Player = ({
 					metadata={{
 						title: title ?? t("show.episodeNoMetadata"),
 						description: data?.overview ?? undefined,
-						imageUri: data?.thumbnail?.high,
+						imageUri: image?.medium,
 						next: next,
 						previous: previous,
 					}}

--- a/front/packages/ui/src/player/index.tsx
+++ b/front/packages/ui/src/player/index.tsx
@@ -65,6 +65,17 @@ const mapData = (
 	};
 };
 
+const formatTitleMetadata = (item: Item) => {
+	if (item.type === "movie") {
+		return item.name;
+	}
+	return `${item.name} (${episodeDisplayNumber({
+		seasonNumber: item.seasonNumber,
+		episodeNumber: item.episodeNumber,
+		absoluteNumber: item.absoluteNumber,
+	})})`;
+};
+
 export const Player = ({
 	slug,
 	type,
@@ -81,10 +92,7 @@ export const Player = ({
 	const [playbackError, setPlaybackError] = useState<string | undefined>(undefined);
 	const { data, error } = useFetch(Player.query(type, slug));
 	const { data: info, error: infoError } = useFetch(Player.infoQuery(type, slug));
-	const image =
-		data && data.type === "episode"
-			? data.show?.poster ?? data?.thumbnail
-			: data?.thumbnail;
+	const image = data && data.type === "episode" ? data.show?.poster ?? data?.poster : data?.poster;
 	const previous =
 		data && data.type === "episode" && data.previousEpisode
 			? `/watch/${data.previousEpisode.slug}?t=0`
@@ -93,15 +101,8 @@ export const Player = ({
 		data && data.type === "episode" && data.nextEpisode
 			? `/watch/${data.nextEpisode.slug}?t=0`
 			: undefined;
-	const title =
-		data &&
-		(data.type === "movie"
-			? data.name
-			: `${data.show!.name} ${episodeDisplayNumber({
-					seasonNumber: data.seasonNumber,
-					episodeNumber: data.episodeNumber,
-					absoluteNumber: data.absoluteNumber,
-				})}`);
+	const title = data && formatTitleMetadata(data);
+	const subtitle = data && data.type === "episode" ? data.show?.name : undefined;
 
 	useVideoKeyboard(info?.subtitles, info?.fonts, previous, next);
 
@@ -145,6 +146,7 @@ export const Player = ({
 				<Video
 					metadata={{
 						title: title ?? t("show.episodeNoMetadata"),
+						subtitle: subtitle ?? undefined,
 						description: data?.overview ?? undefined,
 						imageUri: image?.medium,
 						next: next,

--- a/front/packages/ui/src/player/media-session.tsx
+++ b/front/packages/ui/src/player/media-session.tsx
@@ -26,11 +26,13 @@ import { durationAtom, playAtom, progressAtom } from "./state";
 
 export const MediaSessionManager = ({
 	title,
+	subtitle,
 	imageUri,
 	previous,
 	next,
 }: {
 	title?: string;
+	subtitle?: string;
 	imageUri?: string | null;
 	previous?: string;
 	next?: string;
@@ -45,9 +47,10 @@ export const MediaSessionManager = ({
 		if (!("mediaSession" in navigator)) return;
 		navigator.mediaSession.metadata = new MediaMetadata({
 			title: title,
+			album: subtitle,
 			artwork: imageUri ? [{ src: imageUri }] : undefined,
 		});
-	}, [title, imageUri]);
+	}, [title, subtitle, imageUri]);
 
 	useEffect(() => {
 		if (!("mediaSession" in navigator)) return;

--- a/front/packages/ui/src/player/media-session.tsx
+++ b/front/packages/ui/src/player/media-session.tsx
@@ -26,12 +26,12 @@ import { durationAtom, playAtom, progressAtom } from "./state";
 
 export const MediaSessionManager = ({
 	title,
-	image,
+	imageUri,
 	previous,
 	next,
 }: {
 	title?: string;
-	image?: string | null;
+	imageUri?: string | null;
 	previous?: string;
 	next?: string;
 }) => {
@@ -45,9 +45,9 @@ export const MediaSessionManager = ({
 		if (!("mediaSession" in navigator)) return;
 		navigator.mediaSession.metadata = new MediaMetadata({
 			title: title,
-			artwork: image ? [{ src: image }] : undefined,
+			artwork: imageUri ? [{ src: imageUri }] : undefined,
 		});
-	}, [title, image]);
+	}, [title, imageUri]);
 
 	useEffect(() => {
 		if (!("mediaSession" in navigator)) return;

--- a/front/packages/ui/src/player/state.tsx
+++ b/front/packages/ui/src/player/state.tsx
@@ -116,6 +116,7 @@ export const Video = memo(function Video({
 	startTime?: number | null;
 	metadata: {
 		title?: string;
+		subtitle?: string;
 		description?: string;
 		imageUri?: string;
 		previous?: string;


### PR DESCRIPTION
The `MediaSessionManager` seems to be broken:

<img width="416" alt="Screenshot 2024-08-04 at 19 46 57" src="https://github.com/user-attachments/assets/925d905e-8371-40ea-a85d-4731b7ec58b0">

This PR provides a fix (there was a mismatch between props of `<Video/>` and `<MediaSessionManager/>`)

Additionally, I took the liberty to rework the format of the data passed to `<NativeVideo/>` and `<MediaSessionManager/>`:

- We pass the poster (of the movie or the parent show) instead of the thumbnail
- The pass a _subtitle_, only for episodes, which will be the name of the show
  - Fun fact, NativeVideo actually accept such a prop, didn't know that. For web, it will be considered as the album name

### Screenshots

<img width="416" alt="Screenshot 2024-08-04 at 19 46 45" src="https://github.com/user-attachments/assets/317b607e-323e-4416-831c-c8fd3aa7dd67">
<img width="416" alt="Screenshot 2024-08-04 at 19 47 32" src="https://github.com/user-attachments/assets/65505f07-2eba-4995-b482-3ddabd7d65e5">

