### PR TITLE
Front: Hide Ratings with value equals 0

### DIFF
--- a/front/packages/ui/src/details/header.tsx
+++ b/front/packages/ui/src/details/header.tsx
@@ -329,7 +329,7 @@ export const TitleLine = ({
 						<View
 							{...css({ flexDirection: "row", alignItems: "center", justifyContent: "center" })}
 						>
-							{rating !== null && (
+							{rating !== null && rating !== 0 && (
 								<>
 									<DottedSeparator
 										{...css({ color: { xs: theme.user.contrast, md: theme.colors.white } })}


### PR DESCRIPTION
As discussed, we hide the `<Rating>` component when ratings equal zero (i.e. unknown on TMDB)

## Screenshots

Before: 
![Screenshot 2024-08-07 at 15 35 40](https://github.com/user-attachments/assets/0d4220fd-b406-4420-8fd6-d3eef0c5ce9a)
After: 
![Screenshot 2024-08-07 at 15 36 11](https://github.com/user-attachments/assets/e0fdb3bd-e51d-4971-aa7f-dbbc1d0a8d06)
