### PR TITLE
Front: Add Gradient behind navbar if transparent

### DIFF
--- a/front/apps/web/src/pages/_app.tsx
+++ b/front/apps/web/src/pages/_app.tsx
@@ -201,7 +201,7 @@ const App = ({ Component, pageProps }: AppProps) => {
 												{...props}
 											/>
 										</ConnectionErrorVerifier>
-										<Tooltip id="tooltip" positionStrategy={"fixed"} />
+										<Tooltip id="tooltip" style={{ zIndex: 10 }} positionStrategy={"fixed"} />
 										<SetupChecker />
 									</SnackbarProvider>
 								</PortalProvider>

--- a/front/packages/ui/src/layout.tsx
+++ b/front/packages/ui/src/layout.tsx
@@ -19,6 +19,7 @@
  */
 
 import { Main } from "@kyoo/primitives";
+import { LinearGradient } from "expo-linear-gradient";
 import type { ReactElement } from "react";
 import { useYoshiki, vw } from "yoshiki/native";
 import { Navbar } from "./navbar";
@@ -30,8 +31,7 @@ export const DefaultLayout = ({
 	page: ReactElement;
 	transparent?: boolean;
 }) => {
-	const { css } = useYoshiki();
-
+	const { css, theme } = useYoshiki();
 	return (
 		<>
 			<Navbar
@@ -45,6 +45,22 @@ export const DefaultLayout = ({
 						shadowOpacity: 0,
 					},
 				)}
+				background={
+					transparent ? (
+						<LinearGradient
+							start={{ x: 0, y: 0.25 }}
+							end={{ x: 0, y: 1 }}
+							colors={[theme.themeOverlay, "transparent"]}
+							{...css({
+								height: "100%",
+								position: "absolute",
+								top: 0,
+								left: 0,
+								right: 0,
+							})}
+						/>
+					) : undefined
+				}
 			/>
 			<Main
 				{...css({

--- a/front/packages/ui/src/navbar/index.tsx
+++ b/front/packages/ui/src/navbar/index.tsx
@@ -85,8 +85,8 @@ const SearchBar = forwardRef<TextInput, Stylable>(function SearchBar(props, ref)
 				setQuery(q);
 			}}
 			placeholder={t("navbar.search")}
-			placeholderTextColor={theme.colors.white}
-			containerStyle={{ height: ts(4), flexShrink: 1, borderColor: (theme) => theme.colors.white }}
+			placeholderTextColor={theme.contrast}
+			containerStyle={{ height: ts(4), flexShrink: 1, borderColor: (theme) => theme.contrast }}
 			{...tooltip(t("navbar.search"))}
 			{...props}
 		/>
@@ -177,9 +177,14 @@ export const NavbarRight = () => {
 export const Navbar = ({
 	left,
 	right,
+	background,
 	...props
-}: { left?: ReactElement | null; right?: ReactElement | null } & Stylable) => {
-	const { css } = useYoshiki();
+}: {
+	left?: ReactElement | null;
+	right?: ReactElement | null;
+	background?: ReactElement;
+} & Stylable) => {
+	const { css, theme } = useYoshiki();
 	const { t } = useTranslation();
 
 	return (
@@ -205,6 +210,7 @@ export const Navbar = ({
 				props,
 			)}
 		>
+			{background}
 			<View {...css({ flexDirection: "row", alignItems: "center", height: percent(100) })}>
 				{left !== undefined ? (
 					left


### PR DESCRIPTION
Adds a gradient behind navbar when transparent.

There are a lot of things that I am not happy with, but I hope this can serve as food for though for the future:

- Setting the tooltip's zIndex at 10 is arbitrary
  - Though it's needed so that tooltips do not appear behind the navbar (for example on the search bar)
- I am not a fan of how it looks. To me, this gradient makes the navbar look bulky
- I don't like the way we inject a 'background' into the navbar

# Screenshots

<img width="1484" alt="Screenshot 2024-08-10 at 15 30 03" src="https://github.com/user-attachments/assets/fbe8e2f2-df62-4398-8b4d-bbd246d1b8c2">
<img width="1484" alt="Screenshot 2024-08-10 at 15 30 09" src="https://github.com/user-attachments/assets/4ef454ee-dffd-4db4-a68c-2464ed1ea552">

Closes #251
