### PR TITLE
Front: Improve readability in menus

### DIFF
--- a/front/packages/primitives/src/menu.web.tsx
+++ b/front/packages/primitives/src/menu.web.tsx
@@ -157,6 +157,12 @@ const MenuItem = forwardRef<
 			<style jsx global>{`
 				[data-highlighted] {
 					background: ${theme.variant.accent};
+					svg {
+						fill: ${theme.alternate.contrast};
+					}
+					div {
+						color: ${theme.alternate.contrast};
+					}
 				}
 			`}</style>
 			<Item


### PR DESCRIPTION
This is a draft, as I think there might be a better way to do this.

This improves the readability of menu items on hover.
(This is of web only btw)

## Screenshots

### Before
<img width="371" alt="Screenshot 2024-08-13 at 19 37 05" src="https://github.com/user-attachments/assets/8608bb96-600f-4da6-be00-2895f841ab5f">
<img width="371" alt="Screenshot 2024-08-13 at 19 38 01" src="https://github.com/user-attachments/assets/6e402272-6f03-47a4-9362-fc97b40c1ca4">


### After
<img width="371" alt="Screenshot 2024-08-13 at 19 36 40" src="https://github.com/user-attachments/assets/9eb42f96-38f7-4894-af5b-772fbff57f0b">
<img width="371" alt="Screenshot 2024-08-13 at 19 37 48" src="https://github.com/user-attachments/assets/b50a619c-23bb-4551-b5e7-5decf3b03d13">
