### PR TITLE
Fix playback with avi files missing PTS

### DIFF
--- a/transcoder/Dockerfile
+++ b/transcoder/Dockerfile
@@ -1,9 +1,9 @@
 # FROM golang:1.22 as build
-FROM debian:trixie-slim as build
+FROM debian:trixie-slim AS build
 # those were copied from https://github.com/docker-library/golang/blob/master/Dockerfile-linux.template
 ENV GOTOOLCHAIN=local
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \

--- a/transcoder/Dockerfile.dev
+++ b/transcoder/Dockerfile.dev
@@ -5,8 +5,8 @@
 FROM debian:trixie-slim
 # those were copied from https://github.com/docker-library/golang/blob/master/Dockerfile-linux.template
 ENV GOTOOLCHAIN=local
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \

--- a/transcoder/src/keyframes.go
+++ b/transcoder/src/keyframes.go
@@ -157,6 +157,8 @@ func getVideoKeyframes(path string, video_idx uint32, kf *Keyframe) error {
 		"-loglevel", "error",
 		"-select_streams", fmt.Sprintf("V:%d", video_idx),
 		"-show_entries", "packet=pts_time,flags",
+		// some avi files don't have pts, we use this to ask ffmpeg to generate them (it uses the dts under the hood)
+		"-fflags", "+genpts",
 		"-of", "csv=print_section=0",
 		path,
 	)

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -238,6 +238,11 @@ func (ts *Stream) run(start int32) error {
 		)
 	}
 	args = append(args,
+		// some avi files are missing pts, using this flag makes ffmpeg use dts as pts and prevents an error with
+		// -c:v copy. Only issue: pts is sometime wrong (+1fps than expected) and this leads to some clients refusing
+		// to play the file (they just switch back to the previous quality).
+		// since this is better than errorring or not supporting transmux at all, i'll keep it here for now.
+		"-fflags", "+genpts",
 		"-i", ts.file.Info.Path,
 		// this makes behaviors consistent between soft and hardware decodes.
 		// this also means that after a -ss 50, the output video will start at 50s


### PR DESCRIPTION
AVI doesn't really support H.264 ([source](https://stackoverflow.com/questions/54923062/why-do-i-lose-pts-information-when-encoding-to-h264)). AVI files sometimes don't contain PTS timestamps.

This means keyframe extraction succeed with no keyframes and starting a stream panics.

We can instead use DTS to get keyframe timing ([source](https://trac.ffmpeg.org/ticket/5184)).