### PR TITLE
Feat/localized images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ LIBRARY_LANGUAGES=en
 # If this is true, kyoo will prefer to download the media in the original language of the item.
 MEDIA_PREFER_ORIGINAL_LANGUAGE=false
 # A pattern (regex) to ignore files.
-LIBRARY_IGNORE_PATTERN=".*/[dD]ownloads?/.*|.*\.(mp3|srt|jpg|jpeg|png|gif|bmp|tiff|svg)$|.*[Tt][Rr][Aa][Ii][Ll][Ee][Rr].*"
+LIBRARY_IGNORE_PATTERN=".*/[dD]ownloads?/.*|.*[Tt][Rr][Aa][Ii][Ll][Ee][Rr].*"
 
 # If this is true, new accounts wont have any permissions before you approve them in your admin dashboard.
 REQUIRE_ACCOUNT_VERIFICATION=true

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ CACHE_ROOT=/tmp/kyoo_cache
 LIBRARY_LANGUAGES=en
 # If this is true, kyoo will prefer to download the media in the original language of the item.
 MEDIA_PREFER_ORIGINAL_LANGUAGE=false
-# A pattern (regex) to ignore video files.
-LIBRARY_IGNORE_PATTERN=".*/[dD]ownloads?/.*"
+# A pattern (regex) to ignore files.
+LIBRARY_IGNORE_PATTERN=".*/[dD]ownloads?/.*|.*\.(mp3|srt|jpg|jpeg|png|gif|bmp|tiff|svg)$|.*[Tt][Rr][Aa][Ii][Ll][Ee][Rr].*"
 
 # If this is true, new accounts wont have any permissions before you approve them in your admin dashboard.
 REQUIRE_ACCOUNT_VERIFICATION=true

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ LIBRARY_ROOT=./video
 # It will automatically be cleaned up on kyoo's startup/shutdown/runtime.
 CACHE_ROOT=/tmp/kyoo_cache
 LIBRARY_LANGUAGES=en
+# If this is true, kyoo will prefer to download the media in the original language of the item.
+MEDIA_PREFER_ORIGINAL_LANGUAGE=false
 # A pattern (regex) to ignore video files.
 LIBRARY_IGNORE_PATTERN=".*/[dD]ownloads?/.*"
 

--- a/scanner/matcher/matcher.py
+++ b/scanner/matcher/matcher.py
@@ -52,7 +52,7 @@ class Matcher:
 		if "mimetype" not in raw or not raw["mimetype"].startswith("video"):
 			return
 
-		logger.info("Identied %s: %s", path, raw)
+		logger.info("Identified %s: %s", path, raw)
 
 		title = raw.get("title")
 		if not isinstance(title, str):

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -149,8 +149,6 @@ class TheMovieDatabase(Provider):
 		Returns:
 			list: A list of images, prioritized by localization, original language, and any available image.
 		"""
-		print(f"Trying to get best image for {item['title']} in {lng}")
-		print(f"All available languageCodes: {map(lambda x: x['iso_639_1'], item['images'][key])}")
 		# Order images by size and vote average
 		item["images"][key] = sorted(
 			item["images"][key],
@@ -246,17 +244,18 @@ class TheMovieDatabase(Provider):
 				else [],
 				# TODO: Add cast information
 			)
+			lng_iso639_1 = lng.split("-").pop(0)
 			translation = MovieTranslation(
 				name=movie["title"],
 				tagline=movie["tagline"] if movie["tagline"] else None,
 				tags=list(map(lambda x: x["name"], movie["keywords"]["keywords"])),
 				overview=movie["overview"],
 				posters=self.get_image(
-					self.get_best_image(movie, lng, "posters")
+					self.get_best_image(movie, lng_iso639_1, "posters")
 				),
-				logos=self.get_image(self.get_best_image(movie, lng, "logos")),
+				logos=self.get_image(self.get_best_image(movie, lng_iso639_1, "logos")),
 				thumbnails=self.get_image(
-					self.get_best_image(movie, lng, "backdrops")
+					self.get_best_image(movie, lng_iso639_1, "backdrops")
 				),
 				trailers=[
 					f"https://www.youtube.com/watch?v={x['key']}"
@@ -337,17 +336,18 @@ class TheMovieDatabase(Provider):
 				],
 				# TODO: Add cast information
 			)
+			lng_iso639_1 = lng.split("-").pop(0)
 			translation = ShowTranslation(
 				name=show["name"],
 				tagline=show["tagline"] if show["tagline"] else None,
 				tags=list(map(lambda x: x["name"], show["keywords"]["results"])),
 				overview=show["overview"],
 				posters=self.get_image(
-					self.get_best_image(show, lng, "posters")
+					self.get_best_image(show, lng_iso639_1, "posters")
 				),
-				logos=self.get_image(self.get_best_image(show, lng, "logos")),
+				logos=self.get_image(self.get_best_image(show, lng_iso639_1, "logos")),
 				thumbnails=self.get_image(
-					self.get_best_image(show, lng, "backdrops")
+					self.get_best_image(show, lng_iso639_1, "backdrops")
 				),
 				trailers=[
 					f"https://www.youtube.com/watch?v={x['key']}"

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -145,7 +145,7 @@ class TheMovieDatabase(Provider):
 		Args:
 			item (dict): A dictionary containing item information, including images and language details.
 			lng (str): The preferred language code for the images in ISO 639-1 format.
-
+			key (str): The key to access the images in the item dictionary. (e.g. "posters", "backdrops", "logos")
 		Returns:
 			list: A list of images, prioritized by localization, original language, and any available image.
 		"""

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -196,7 +196,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images",
-					"include_image_language": f"{get_iso_639_1_codes().join(',')},null",
+					"include_image_language": f"{lng_iso639_1},{get_iso_639_1_codes().join(',')},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", movie)
@@ -293,7 +293,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images,external_ids",
-					"include_image_language": f"{get_iso_639_1_codes().join(',')},null",
+					"include_image_language": f"{lng_iso639_1},{get_iso_639_1_codes().join(',')},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", show)

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -196,7 +196,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images",
-					"include_image_language": f"{lng_iso639_1},{get_iso_639_1_codes().join(',')},null",
+					"include_image_language": f"{lng_iso639_1},{','.join(get_iso_639_1_codes())},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", movie)
@@ -293,7 +293,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images,external_ids",
-					"include_image_language": f"{lng_iso639_1},{get_iso_639_1_codes().join(',')},null",
+					"include_image_language": f"{lng_iso639_1},{','.join(get_iso_639_1_codes())},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", show)

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -153,7 +153,7 @@ class TheMovieDatabase(Provider):
 		# Order images by size and vote average
 		item["images"][key] = sorted(
 			item["images"][key],
-			key=lambda x: (x.get("width", 0), x.get("vote_average", 0)),
+			key=lambda x: (x.get("vote_average", 0), x.get("width", 0)),
 			reverse=True,
 		)
 
@@ -189,7 +189,7 @@ class TheMovieDatabase(Provider):
 			)
 			localized_images = sorted(
 				images[key],
-				key=lambda x: (x.get("width", 0), x.get("vote_average", 0)),
+				key=lambda x: x.get("vote_average", 0),
 				reverse=True,
 			)
 
@@ -216,6 +216,7 @@ class TheMovieDatabase(Provider):
 					"include_image_language": f"{lng.language},null,{original_language}",
 				},
 			)
+			movie["media_type"] = "movie"
 			logger.debug("TMDb responded: %s", movie)
 
 			ret = Movie(
@@ -307,6 +308,7 @@ class TheMovieDatabase(Provider):
 					"include_image_language": f"{lng.language},null,en",
 				},
 			)
+			show["media_type"] = "tv"
 			logger.debug("TMDb responded: %s", show)
 
 			ret = Show(

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -193,7 +193,7 @@ class TheMovieDatabase(Provider):
 				reverse=True,
 			)
 
-		return localized_images
+		return self.get_image(localized_images)
 
 	async def search_movie(self, name: str, year: Optional[int]) -> Movie:
 		search_results = (
@@ -268,13 +268,9 @@ class TheMovieDatabase(Provider):
 				tagline=movie["tagline"] if movie["tagline"] else None,
 				tags=list(map(lambda x: x["name"], movie["keywords"]["keywords"])),
 				overview=movie["overview"],
-				posters=self.get_image(
-					await self.get_best_image(movie, lng, "posters")
-				),
-				logos=self.get_image(await self.get_best_image(movie, lng, "logos")),
-				thumbnails=self.get_image(
-					await self.get_best_image(movie, lng, "backdrops")
-				),
+				posters=(await self.get_best_image(movie, lng, "posters")),
+				logos=(await self.get_best_image(movie, lng, "logos")),
+				thumbnails=(await self.get_best_image(movie, lng, "backdrops")),
 				trailers=[
 					f"https://www.youtube.com/watch?v={x['key']}"
 					for x in movie["videos"]["results"]
@@ -361,13 +357,9 @@ class TheMovieDatabase(Provider):
 				tagline=show["tagline"] if show["tagline"] else None,
 				tags=list(map(lambda x: x["name"], show["keywords"]["results"])),
 				overview=show["overview"],
-				posters=self.get_image(
-					await self.get_best_image(show, lng, "posters")
-				),
-				logos=self.get_image(await self.get_best_image(show, lng, "logos")),
-				thumbnails=self.get_image(
-					await self.get_best_image(show, lng, "backdrops")
-				),
+				posters=(await self.get_best_image(show, lng, "posters")),
+				logos=(await self.get_best_image(show, lng, "logos")),
+				thumbnails=(await self.get_best_image(show, lng, "backdrops")),
 				trailers=[
 					f"https://www.youtube.com/watch?v={x['key']}"
 					for x in show["videos"]["results"]

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -102,7 +102,8 @@ class TheMovieDatabase(Provider):
 
 	def merge_translations(self, host, translations, *, languages: list[Language]):
 		host.translations = {
-			k.to_tag(): v.translations[k.to_tag()] for k, v in zip(languages, translations)
+			k.to_tag(): v.translations[k.to_tag()]
+			for k, v in zip(languages, translations)
 		}
 		return host
 
@@ -202,9 +203,13 @@ class TheMovieDatabase(Provider):
 		if len(search_results) == 0:
 			raise ProviderError(f"No result for a movie named: {name}")
 		search = self.get_best_result(search_results, name, year)
-		return await self.identify_movie(search["id"], original_language=search["original_language"])
+		return await self.identify_movie(
+			search["id"], original_language=search["original_language"]
+		)
 
-	async def identify_movie(self, movie_id: str, original_language: Optional[str] = "null") -> Movie:
+	async def identify_movie(
+		self, movie_id: str, original_language: Optional[str] = "null"
+	) -> Movie:
 		languages = self.get_languages()
 
 		async def for_language(lng: Language) -> Movie:

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import Awaitable, Callable, Dict, List, Optional, Any, TypeVar
 from itertools import accumulate, zip_longest
 
-from providers.utils import ProviderError, get_iso_639_1_codes
+from providers.utils import ProviderError
 from matcher.cache import cache
 
 from ..provider import Provider
@@ -184,9 +184,9 @@ class TheMovieDatabase(Provider):
 		if len(search_results) == 0:
 			raise ProviderError(f"No result for a movie named: {name}")
 		search = self.get_best_result(search_results, name, year)
-		return await self.identify_movie(search["id"])
+		return await self.identify_movie(search["id"], original_language=search["original_language"])
 
-	async def identify_movie(self, movie_id: str) -> Movie:
+	async def identify_movie(self, movie_id: str, original_language: str) -> Movie:
 		languages = self.get_languages()
 
 		async def for_language(lng: str) -> Movie:
@@ -196,7 +196,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images",
-					"include_image_language": f"{lng_iso639_1},{','.join(get_iso_639_1_codes())},null",
+					"include_image_language": f"{lng_iso639_1},null,{original_language}",
 				},
 			)
 			logger.debug("TMDb responded: %s", movie)
@@ -293,7 +293,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images,external_ids",
-					"include_image_language": f"{lng_iso639_1},{','.join(get_iso_639_1_codes())},null",
+					"include_image_language": f"{lng_iso639_1},null,en",
 				},
 			)
 			logger.debug("TMDb responded: %s", show)

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -149,6 +149,8 @@ class TheMovieDatabase(Provider):
 		Returns:
 			list: A list of images, prioritized by localization, original language, and any available image.
 		"""
+		print(f"Trying to get best image for {item['title']} in {lng}")
+		print(f"All available languageCodes: {list(map(lambda x: x['iso_639_1'], item['images'][key]))}")
 		# Order images by size and vote average
 		item["images"][key] = sorted(
 			item["images"][key],
@@ -163,8 +165,11 @@ class TheMovieDatabase(Provider):
 			if image.get("iso_639_1") == lng
 		]
 
+		print(f"Localized images: {localized_images}")
+
 		# Step 2: If no localized images, try images in the original language
 		if not localized_images:
+			print(f"Could not find localized images for {lng}, trying original language")
 			localized_images = [
 				image
 				for image in item["images"][key]
@@ -173,6 +178,7 @@ class TheMovieDatabase(Provider):
 
 		# Step 3: If still no images, use any available images
 		if not localized_images:
+			print(f"Could not find images for {lng} or original language, using any available")
 			localized_images = item["images"][key]
 
 		return localized_images

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -204,7 +204,7 @@ class TheMovieDatabase(Provider):
 		search = self.get_best_result(search_results, name, year)
 		return await self.identify_movie(search["id"], original_language=search["original_language"])
 
-	async def identify_movie(self, movie_id: str, original_language: Optional[str]) -> Movie:
+	async def identify_movie(self, movie_id: str, original_language: Optional[str] = "null") -> Movie:
 		languages = self.get_languages()
 
 		async def for_language(lng: Language) -> Movie:

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -204,7 +204,7 @@ class TheMovieDatabase(Provider):
 		search = self.get_best_result(search_results, name, year)
 		return await self.identify_movie(search["id"], original_language=search["original_language"])
 
-	async def identify_movie(self, movie_id: str, original_language: str) -> Movie:
+	async def identify_movie(self, movie_id: str, original_language: Optional[str]) -> Movie:
 		languages = self.get_languages()
 
 		async def for_language(lng: Language) -> Movie:

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -172,7 +172,7 @@ class TheMovieDatabase(Provider):
 			localized_images = [
 				image
 				for image in item["images"][key]
-				if image.get("iso_639_1") == item["original_language"]
+				if image.get("iso_639_1") == item.get("original_language")
 			]
 
 		# Step 3: If still no images, use any available images

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -180,7 +180,7 @@ class TheMovieDatabase(Provider):
 		# Although doing another API call is not ideal, this would only be called very rarely.
 		if not localized_images:
 			logger.debug(
-				"No images found for %s %s. Calling TMDB images API.",
+				"[Fallback] No images found for %s %s. Calling TMDB images API.",
 				item["media_type"],
 				item["id"],
 			)

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -201,8 +201,9 @@ class TheMovieDatabase(Provider):
 		if len(search_results) == 0:
 			raise ProviderError(f"No result for a movie named: {name}")
 		search = self.get_best_result(search_results, name, year)
+		original_language = Language.get(search["original_language"])
 		return await self.identify_movie(
-			search["id"], original_language=search["original_language"]
+			search["id"], original_language=original_language
 		)
 
 	async def identify_movie(

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -140,7 +140,9 @@ class TheMovieDatabase(Provider):
 			},
 		)
 
-	def get_best_image(self, item: dict[str, Any], lng: Language, key: str) -> list[dict]:
+	def get_best_image(
+		self, item: dict[str, Any], lng: Language, key: str
+	) -> list[dict]:
 		"""
 		Retrieves the best available images for a item based on localization.
 

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -149,6 +149,15 @@ class TheMovieDatabase(Provider):
 		Returns:
 			list: A list of images, prioritized by localization, original language, and any available image.
 		"""
+		print(f"Trying to get best image for {item['title']} in {lng}")
+		print(f"All available languageCodes: {map(lambda x: x['iso_639_1'], item['images'][key])}")
+		# Order images by size and vote average
+		item["images"][key] = sorted(
+			item["images"][key],
+			key=lambda x: (x.get("width", 0), x.get("vote_average", 0)),
+			reverse=True,
+		)
+
 		# Step 1: Try to get localized images
 		localized_images = [
 			image

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -196,11 +196,13 @@ class TheMovieDatabase(Provider):
 		languages = self.get_languages()
 
 		async def for_language(lng: str) -> Movie:
+			lng_iso639_1 = lng.split("-").pop(0)
 			movie = await self.get(
 				f"movie/{movie_id}",
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images",
+					"include_image_language": f"{lng},{lng_iso639_1},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", movie)
@@ -250,7 +252,6 @@ class TheMovieDatabase(Provider):
 				else [],
 				# TODO: Add cast information
 			)
-			lng_iso639_1 = lng.split("-").pop(0)
 			translation = MovieTranslation(
 				name=movie["title"],
 				tagline=movie["tagline"] if movie["tagline"] else None,
@@ -290,11 +291,15 @@ class TheMovieDatabase(Provider):
 		languages = self.get_languages()
 
 		async def for_language(lng: str) -> Show:
+			# ISO 639-1 (eg. "en") is required as TMDB does not support fetching images
+			# by ISO 639-2 + ISO 3166-1 alpha-2 (eg. "en-US")
+			lng_iso639_1 = lng.split("-").pop(0)
 			show = await self.get(
 				f"tv/{show_id}",
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images,external_ids",
+					"include_image_language": f"{lng},{lng_iso639_1},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", show)
@@ -342,7 +347,6 @@ class TheMovieDatabase(Provider):
 				],
 				# TODO: Add cast information
 			)
-			lng_iso639_1 = lng.split("-").pop(0)
 			translation = ShowTranslation(
 				name=show["name"],
 				tagline=show["tagline"] if show["tagline"] else None,

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -742,6 +742,8 @@ class TheMovieDatabase(Provider):
 				f"collection/{provider_id}",
 				params={
 					"language": lng.to_tag(),
+					"append_to_response": "images",
+					"include_image_language": f"{lng.language},null,en",
 				},
 			)
 			logger.debug("TMDb responded: %s", collection)
@@ -757,13 +759,9 @@ class TheMovieDatabase(Provider):
 			translation = CollectionTranslation(
 				name=collection["name"],
 				overview=collection["overview"],
-				posters=[
-					f"https://image.tmdb.org/t/p/original{collection['poster_path']}"
-				],
+				posters=self.get_best_image(collection, lng, "posters"),
 				logos=[],
-				thumbnails=[
-					f"https://image.tmdb.org/t/p/original{collection['backdrop_path']}"
-				],
+				thumbnails=self.get_best_image(collection, lng, "backdrops"),
 			)
 			ret.translations = {lng.to_tag(): translation}
 			return ret

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import Awaitable, Callable, Dict, List, Optional, Any, TypeVar
 from itertools import accumulate, zip_longest
 
-from providers.utils import ProviderError
+from providers.utils import ProviderError, get_iso_639_1_codes
 from matcher.cache import cache
 
 from ..provider import Provider
@@ -149,8 +149,6 @@ class TheMovieDatabase(Provider):
 		Returns:
 			list: A list of images, prioritized by localization, original language, and any available image.
 		"""
-		print(f"Trying to get best image for {item['title']} in {lng}")
-		print(f"All available languageCodes: {list(map(lambda x: x['iso_639_1'], item['images'][key]))}")
 		# Order images by size and vote average
 		item["images"][key] = sorted(
 			item["images"][key],
@@ -165,11 +163,8 @@ class TheMovieDatabase(Provider):
 			if image.get("iso_639_1") == lng
 		]
 
-		print(f"Localized images: {localized_images}")
-
 		# Step 2: If no localized images, try images in the original language
 		if not localized_images:
-			print(f"Could not find localized images for {lng}, trying original language")
 			localized_images = [
 				image
 				for image in item["images"][key]
@@ -178,7 +173,6 @@ class TheMovieDatabase(Provider):
 
 		# Step 3: If still no images, use any available images
 		if not localized_images:
-			print(f"Could not find images for {lng} or original language, using any available")
 			localized_images = item["images"][key]
 
 		return localized_images
@@ -202,7 +196,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images",
-					"include_image_language": f"{lng},{lng_iso639_1},null",
+					"include_image_language": f"{get_iso_639_1_codes().join(',')},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", movie)
@@ -299,7 +293,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng,
 					"append_to_response": "alternative_titles,videos,credits,keywords,images,external_ids",
-					"include_image_language": f"{lng},{lng_iso639_1},null",
+					"include_image_language": f"{get_iso_639_1_codes().join(',')},null",
 				},
 			)
 			logger.debug("TMDb responded: %s", show)

--- a/scanner/providers/implementations/themoviedatabase.py
+++ b/scanner/providers/implementations/themoviedatabase.py
@@ -219,7 +219,7 @@ class TheMovieDatabase(Provider):
 				params={
 					"language": lng.to_tag(),
 					"append_to_response": "alternative_titles,videos,credits,keywords,images",
-					"include_image_language": f"{lng.language},null,{original_language.language if original_language else ""}",
+					"include_image_language": f"{lng.language},null,{original_language.language if original_language else ''}",
 				},
 			)
 			logger.debug("TMDb responded: %s", movie)

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 	from providers.types.episode import Episode
 	from providers.types.collection import Collection
 
+def get_iso_639_1_codes() -> list[str]:
+	return [code for code in Language.all_codes() if len(code) == 2]
 
 def format_date(date: date | int | None) -> str | None:
 	if date is None:
@@ -28,7 +30,7 @@ def normalize_lang(lang: str) -> str:
 
 # For now, the API of kyoo only support one language so we remove the others.
 default_languages = os.environ.get("LIBRARY_LANGUAGES", "").split(",")
-image_prefer_original_language = os.environ.get("IMAGE_PREFER_ORIGINAL_LANGUAGE", "false").lower() == "true"
+media_prefer_original_language = os.environ.get("MEDIA_PREFER_ORIGINAL_LANGUAGE", "false").lower() == "true"
 
 
 def sort_translations(
@@ -65,7 +67,7 @@ def select_image(
 		chain(
 			*(
 				getattr(trans, kind)
-				for trans in sort_translations(value, prefer_orginal=image_prefer_original_language)
+				for trans in sort_translations(value, prefer_orginal=media_prefer_original_language)
 			)
 		),
 		None,

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from datetime import date
 from itertools import chain
-from langcodes import Language, LANGUAGE_ALPHA3
+from langcodes import Language
 from typing import TYPE_CHECKING, Literal, Any, Optional
 
 if TYPE_CHECKING:
@@ -12,9 +12,6 @@ if TYPE_CHECKING:
 	from providers.types.season import Season
 	from providers.types.episode import Episode
 	from providers.types.collection import Collection
-
-def get_iso_639_1_codes() -> list[str]:
-	return [code for code in LANGUAGE_ALPHA3.keys() if len(code) == 2]
 
 def format_date(date: date | int | None) -> str | None:
 	if date is None:

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from datetime import date
 from itertools import chain
-from langcodes import Language
+from langcodes import Language, LANGUAGE_ALPHA3
 from typing import TYPE_CHECKING, Literal, Any, Optional
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 	from providers.types.collection import Collection
 
 def get_iso_639_1_codes() -> list[str]:
-	return [code for code in Language.all_codes() if len(code) == 2]
+	return [code for code in LANGUAGE_ALPHA3.keys() if len(code) == 2]
 
 def format_date(date: date | int | None) -> str | None:
 	if date is None:

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 	from providers.types.episode import Episode
 	from providers.types.collection import Collection
 
+
 def format_date(date: date | int | None) -> str | None:
 	if date is None:
 		return None
@@ -27,7 +28,9 @@ def normalize_lang(lang: str) -> str:
 
 # For now, the API of kyoo only support one language so we remove the others.
 default_languages = os.environ.get("LIBRARY_LANGUAGES", "").split(",")
-media_prefer_original_language = os.environ.get("MEDIA_PREFER_ORIGINAL_LANGUAGE", "false").lower() == "true"
+media_prefer_original_language = (
+	os.environ.get("MEDIA_PREFER_ORIGINAL_LANGUAGE", "false").lower() == "true"
+)
 
 
 def sort_translations(
@@ -64,7 +67,9 @@ def select_image(
 		chain(
 			*(
 				getattr(trans, kind)
-				for trans in sort_translations(value, prefer_orginal=media_prefer_original_language)
+				for trans in sort_translations(
+					value, prefer_orginal=media_prefer_original_language
+				)
 			)
 		),
 		None,

--- a/scanner/providers/utils.py
+++ b/scanner/providers/utils.py
@@ -28,6 +28,7 @@ def normalize_lang(lang: str) -> str:
 
 # For now, the API of kyoo only support one language so we remove the others.
 default_languages = os.environ.get("LIBRARY_LANGUAGES", "").split(",")
+image_prefer_original_language = os.environ.get("IMAGE_PREFER_ORIGINAL_LANGUAGE", "false").lower() == "true"
 
 
 def sort_translations(
@@ -64,7 +65,7 @@ def select_image(
 		chain(
 			*(
 				getattr(trans, kind)
-				for trans in sort_translations(value, prefer_orginal=True)
+				for trans in sort_translations(value, prefer_orginal=image_prefer_original_language)
 			)
 		),
 		None,


### PR DESCRIPTION
* Fix: Add .env setting to prevent Kyoo for always downloading images in the original language. (bug?)
* Feat: Add an easy-to-understand algotithim to pick the best available image from TMDB.
* Fix: Add `include_image_language` querystring on tmdb request to include more image options and prevent empty posters for less known/rare media or for when `{ISO-639-2}-{ISO-3166-1-alpha-2}` langcodes are used on setup (eg. pt-BR).