### PR TITLE
Document scanner's v5 workflow

### DIFF
--- a/scanner/README.md
+++ b/scanner/README.md
@@ -1,0 +1,69 @@
+# Scanner
+
+## Workflow (for v5, not current)
+
+In order of action:
+
+ - Scanner gets `/videos` & scan file system to list all new videos
+ - Scanner guesses as much as possible from filename/path ALONE (no external database query).
+   - Format should be:
+     ```json5
+     {
+         path: string,
+         version: number,
+         part: number | null,
+         rendering: sha(path except version & part),
+         guess: {
+             kind: movie | episode | trailer | interview | ...,
+             name: string,
+             year: number | null,
+             season?: number,
+             episode?: number,
+             ...
+          },
+     }
+     ```
+
+     - Apply remaps from lists (AnimeList + thexem). Format is now:
+     ```json5
+     {
+         path: string,
+         version: number,
+         part: number | null,
+         rendering: sha(path except version & part),
+         guess: {
+             kind: movie | episode | trailer | interview | ...,
+             name: string,
+             year: number | null,
+             season?: number,
+             episodes?: number[],
+             absolutes?: number[],
+             externalId: Record<string, {showId, season, number}[]>,
+             remap: {
+                 from: "thexem",
+                 oldSeason: number,
+                 oldEpisodes: number[],
+              },
+             ...
+          },
+     }
+     ```
+ - If kind is episode, try to find the serie's id on kyoo (using the previously fetched data from `/videos`):
+   - if another video in the list of already registered videos has the same `kind`, `name` & `year`, assume it's the same
+   - if a match is found, add to the video's json:
+   ```json5
+   {
+       entries: (uuid | slug | {
+           show: uuid | slug,
+           season: number,
+           episode: number,
+           externalId?: Record<string, {showId, season, number}> // takes priority over season/episode for matching if we have one
+       })[],
+   }
+   ```
+ - Scanner pushes everything to the api in a single post `/videos` call
+ - Api registers every video in the database
+ - For each video without an associated entry, the guess data + the video's id is sent to the Matcher via a queue.
+ - Matcher retrieves metadata from the movie/serie + ALL episodes/seasons (from an external provider)
+ - Matcher pushes every metadata to the api (if there are 1000 episodes but only 1 video, still push the 1000 episodes)
+


### PR DESCRIPTION
Part of #597

For v5, we will rework a lot of things in the scanning process. This PR creates a document that details the scanning workflow.

Big changes compared to current version include:
 - The api knows & register even episodes we don't have videos for (or that are not aired).
   - Episodes missing a video will be displayed in the app accordingly.
   - This allows the user to know there's an episode missing and not inadvertently skip one. 
   - We could use this information in admin dashboards.
   - Fetching all episodes was already needed in some cases, this would make them easier.
 - Videos are saved in database before we register their series/movie.
   - We can display them in the interface as `loading` or `fetching-data`.
   - If metadata matching fails, we can still play them.
   - We can manually correct the guess & continue the registration flow.
 - Metadata guesses are saved in database (just guesses based on file name, not external db data)
   - This allows correction to also apply to other episodes of the same series.
   - It gives better information to the user as to why it was guessed this way (or at least it improves the debugging experience for us).