### PR TITLE
Add helm chart test and release workflows

### DIFF
--- a/.github/workflows/helm-release-chart.yml
+++ b/.github/workflows/helm-release-chart.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
      - v*
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/helm-release-chart.yml
+++ b/.github/workflows/helm-release-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
      - v*
-  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/helm-release-chart.yml
+++ b/.github/workflows/helm-release-chart.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
      - v*
-    paths:
-    - chart/**
   workflow_dispatch:
 
 jobs:
@@ -33,8 +31,11 @@ jobs:
     - name: Package Helm Chart
       working-directory: chart
       run: |
-        helm package .
+        export tag=$(echo ${GITHUB_REF#refs/tags/} | sed 's/^v//')
+        helm package ./chart --version $tag --app-version $tag
         mv *.tgz ../packaged-chart.tgz
+        env:
+          GITHUB_REF: ${{ github.ref }}
 
     - name: Push Helm Chart to GHCR
       run: |

--- a/.github/workflows/helm-release-chart.yml
+++ b/.github/workflows/helm-release-chart.yml
@@ -1,0 +1,43 @@
+name: Release Helm Chart
+on:
+  push:
+    tags:
+     - v*
+    paths:
+    - chart/**
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update Helm Dependencies
+      working-directory: chart
+      run: |
+        helm dependency update
+
+    - name: Package Helm Chart
+      working-directory: chart
+      run: |
+        helm package .
+        mv *.tgz ../packaged-chart.tgz
+
+    - name: Push Helm Chart to GHCR
+      env:
+        HELM_EXPERIMENTAL_OCI: 1
+      run: |
+        helm push packaged-chart.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts

--- a/.github/workflows/helm-release-chart.yml
+++ b/.github/workflows/helm-release-chart.yml
@@ -37,7 +37,5 @@ jobs:
         mv *.tgz ../packaged-chart.tgz
 
     - name: Push Helm Chart to GHCR
-      env:
-        HELM_EXPERIMENTAL_OCI: 1
       run: |
         helm push packaged-chart.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts

--- a/.github/workflows/helm-release-chart.yml
+++ b/.github/workflows/helm-release-chart.yml
@@ -24,16 +24,13 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Update Helm Dependencies
-      working-directory: chart
       run: |
-        helm dependency update
+        helm dependency update ./chart
 
     - name: Package Helm Chart
-      working-directory: chart
       run: |
         export tag=$(echo ${GITHUB_REF#refs/tags/} | sed 's/^v//')
         helm package ./chart --version $tag --app-version $tag
-        mv *.tgz ../packaged-chart.tgz
         env:
           GITHUB_REF: ${{ github.ref }}
 

--- a/.github/workflows/helm-test-chart.yml
+++ b/.github/workflows/helm-test-chart.yml
@@ -1,0 +1,43 @@
+name: Test Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-helm-chart:
+    name: Test Helm Chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint the Helm chart
+        run: |
+          helm lint ./chart
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@v1
+
+      - name: Install Helm chart in Kind cluster (Dry Run)
+        run: |
+          helm dependency update ./chart
+          helm install test-release ./chart --dry-run --debug
+
+      - name: Deploy Helm chart to Kind cluster
+        run: |
+          helm install test-release ./chart
+
+      - name: Verify Helm release
+        run: |
+          kubectl get all
+
+      - name: Cleanup Kind cluster
+        run: |
+          kind delete cluster

--- a/.github/workflows/helm-test-chart.yml
+++ b/.github/workflows/helm-test-chart.yml
@@ -6,6 +6,7 @@ on:
       - master
       - next
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test-helm-chart:

--- a/.github/workflows/helm-test-chart.yml
+++ b/.github/workflows/helm-test-chart.yml
@@ -3,7 +3,8 @@ name: Test Helm Chart
 on:
   push:
     branches:
-      - main
+      - master
+      - next
   pull_request:
 
 jobs:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0
+version: 0.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Relates to #633 
Creates workflow to test chart using a `kind` cluster. (successful test here: https://github.com/joryirving/Kyoo/actions/runs/12244677078)
Creates workflow to publish chart (example here: https://github.com/joryirving/Kyoo/pkgs/container/helm-charts%2Fkyoo)

Bumps chart version to `0.0.1`