### PR TITLE
feat(helm): Secret creation + rework values structures

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,27 +1,10 @@
 apiVersion: v2
 name: kyoo
 description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+version: 0.0.1
 appVersion: "4.7.0"
+icon: https://github.com/zoriya/Kyoo/blob/master/icons/icon-256x256.png?raw=true
 
 dependencies:
 - condition: meilisearch.enabled

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,87 +1,49 @@
 # helm chart
 
 # Recomendations
+
 This helm chart includes subcharts for Meilisearch, Postgres, and RabbitMQ.  Those resources should be managed outside of this Helm release.
 
 ## Postgres
+
 Kyoo consists of multiple microservices.  Best practice is for each microservice to use its own database.  Kyoo workloads support best practices or sharing a single postgres database.  Please see the `POSTGRES_SCHEMA` setting for additional information.
 
 Strongly recomended to use a Kubernetes operator for managing Postgres.
 
 ## Storage
-Kyoo currently uses storage volumes for media, backend-storage, and transcoder-storage.  Media content tends to consume a large amount of space and Kubernetes storage interfaces tend to replicate across nodes.  Consider hosting the data outside of Kubernetes or assigning one node to handle storage.
+
+Kyoo currently uses storage volumes for media, backend-storage, and transcoder-storage.  Media content tends to consume a large amount of space and Kubernetes storage interfaces tend to replicate across nodes. Consider hosting the data outside of Kubernetes (e.g by using a networked file system like NFS) or assigning one node to handle storage.
 
 Storage for backend and transcoder will eventually be moved into a datastore application.
 
 # Quickstart
-Below provides an example for deploying Kyoo and its dependencies.  This is a minimalist setup that is not intended for longterm use.  This approach uses a single Postgres instance and initializes mutliple databases.  
 
-```sh
-helm upgrade kyoo . --install --values myvalues.yaml
+Below provides an example for deploying Kyoo and its dependencies.  This is a minimalist setup that is not intended for longterm use.  This approach uses a single Postgres instance and initializes multiple databases.
+
+Clone Kyoo and navigate to the `chart` directory.
+```bash
+git clone https://github.com/zoriya/kyoo.git
+cd kyoo/chart
 ```
-`myvaules.yaml` content
+
+Install the helm chart :
+
+```bash
+helm upgrade kyoo . --install -n kyoo --create-namespace
+```
+
+For production use, it is highly recommended to use a values file to configure unique secrets and settings.
+
 ```yaml
 kyoo:
-  address: https://kyoo.mydomain.com
-meilisearch:
-  enabled: true
-postgresql:
-  enabled: true
-rabbitmq:
-  enabled: true
-extraObjects:
-  - apiVersion: v1
-    kind: Secret
-    metadata:
-      name: bigsecret
-    type: Opaque
+  secrets:
     stringData:
-      #KYOO
-      # The following value should be set to a random sequence of characters.
-      # You MUST change it when installing kyoo (for security)
-      # You can input multiple api keys separated by a ,
-      kyoo_apikeys: yHXWGsjfjE6sy6UxavqmTUYxgCFYek
-      # Keep those empty to use kyoo's default api key. You can also specify a custom API key if you want.
-      # go to https://www.themoviedb.org/settings/api and copy the api key (not the read access token, the api key)
-      tmdb_apikey: ""
-      tvdb_apikey: ""
-      tvdb_pin: ""
-      #RESOURCES
-      # meilisearch does not allow mapping their key in yet.
       MEILI_MASTER_KEY: barkLike8SuperDucks
       postgres_user: kyoo_all
       postgres_password: watchSomething4me
       rabbitmq_user: kyoo_all
       rabbitmq_password: youAreAmazing2
       rabbitmq_cookie: mmmGoodCookie
-  - kind: PersistentVolumeClaim
-    apiVersion: v1
-    metadata:
-      name: back-storage
-    spec:
-      accessModes:
-        - "ReadWriteOnce"
-      resources:
-        requests:
-          storage: "3Gi"
-  - kind: PersistentVolumeClaim
-    apiVersion: v1
-    metadata:
-      name: media
-    spec:
-      accessModes:
-        - "ReadOnlyMany"
-      resources:
-        requests:
-          storage: "3Gi"
-  - kind: PersistentVolumeClaim
-    apiVersion: v1
-    metadata:
-      name: transcoder-storage
-    spec:
-      accessModes:
-        - "ReadWriteOnce"
-      resources:
-        requests:
-          storage: "3Gi"
 ```
+
+Consult the `values.yaml` file for additional configuration options.

--- a/chart/templates/autosync/deployment.yaml
+++ b/chart/templates/autosync/deployment.yaml
@@ -1,28 +1,37 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- /*
+  To avoid having empty annotations, we check if both global and component annotations are set.
+  */}}
+  {{- if and (.Values.global.podAnnotations) (.Values.autosync.podAnnotations) }}
   {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.autosync.deploymentAnnotations) }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
+  {{- end }}
   name: {{ include "kyoo.autosync.fullname" . }}
   labels:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.autosync.name "name" .Values.autosync.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.autosync.replicaCount }}
+  strategy:
+    {{- toYaml .Values.autosync.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.autosync.name) | nindent 6 }}
   template:
     metadata:
+      {{- if and (.Values.global.podAnnotations) (.Values.autosync.podAnnotations) }}
       annotations:
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.autosync.podAnnotations) }}
-        {{- range $key, $value := . }}
-        {{ $key }}: {{ $value | quote }}
+          {{- range $key, $value := . }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.autosync.name "name" .Values.autosync.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.autosync.podLabels) }}
@@ -33,7 +42,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.securityContext }}
+      {{- with .Values.scanner.kyoo_scanner.containerSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -42,25 +51,27 @@ spec:
         - name: main
           image: {{ .Values.autosync.kyoo_autosync.image.repository | default (printf "%s/kyoo_autosync" .Values.global.image.repositoryBase) }}:{{ default (include "kyoo.defaultTag" .) .Values.autosync.kyoo_autosync.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+          {{- if .Values.autosync.kyoo_autosync.extraArgs }}
           args:
             {{- with .Values.autosync.kyoo_autosync.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           env:
             - name: RABBITMQ_HOST
-              value: {{ .Values.global.rabbitmq.host | quote }}
+              value: {{ .Values.rabbitmq.host | quote }}
             - name: RABBITMQ_PORT
-              value: {{ .Values.global.rabbitmq.port | quote }}
+              value: {{ .Values.rabbitmq.port | quote }}
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_autosync.userKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_autosync.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_autosync.userKey }}
+                  name: {{ .Values.rabbitmq.kyoo_autosync.existingSecret }}
             - name: RABBITMQ_DEFAULT_PASS
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_autosync.passwordKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_autosync.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_autosync.passwordKey }}
+                  name: {{ .Values.rabbitmq.kyoo_autosync.existingSecret }}
             {{- with (concat .Values.global.extraEnv .Values.autosync.kyoo_autosync.extraEnv) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -84,7 +95,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.autosync.kyoo_autosync.extraContainers }}
+        {{- with .Values.autosync.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.autosync.extraInitContainers }}

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -1,10 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.back.deploymentAnnotations) }}
+  {{- if and (.Values.global.deploymentAnnotations) (.Values.back.deploymentAnnotations) }}
+    {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.back.deploymentAnnotations) }}
   annotations:
-    {{- range $key, $value := . }}
-    {{ $key }}: {{ $value | quote }}
+      {{- range $key, $value := . }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
   {{- end }}
   name: {{ include "kyoo.back.fullname" . }}
@@ -12,17 +14,21 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.back.name "name" .Values.back.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.back.replicaCount }}
+  strategy:
+    {{- toYaml .Values.back.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.back.name) | nindent 6 }}
   template:
     metadata:
+      {{- if and (.Values.global.podAnnotations) (.Values.back.podAnnotations) }}
       annotations:
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.back.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.back.name "name" .Values.back.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.back.podLabels) }}
@@ -33,7 +39,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.securityContext }}
+      {{- with .Values.back.kyoo_back.containerSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -42,10 +48,12 @@ spec:
         - name: migrations
           image: {{ .Values.back.kyoo_migrations.image.repository | default (printf "%s/kyoo_migrations" .Values.global.image.repositoryBase) }}:{{ default (include "kyoo.defaultTag" .) .Values.back.kyoo_migrations.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+          {{- if .Values.back.kyoo_migrations.extraArgs }}
           args:
             {{- with .Values.back.kyoo_migrations.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           env:
             - name: POSTGRES_USER
               valueFrom:
@@ -70,10 +78,12 @@ spec:
         - name: main
           image: {{ .Values.back.kyoo_back.image.repository | default (printf "%s/kyoo_back" .Values.global.image.repositoryBase) }}:{{ default (include "kyoo.defaultTag" .) .Values.back.kyoo_back.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+          {{- if .Values.back.kyoo_back.extraArgs }}
           args:
             {{- with .Values.back.kyoo_back.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           env:
             - name: TRANSCODER_URL
               value: "http://{{ include "kyoo.transcoder.fullname" . }}:7666"
@@ -86,10 +96,14 @@ spec:
             - name: UNLOGGED_PERMISSIONS
               value: {{ .Values.kyoo.unloggedPermissions | quote}}
             - name: KYOO_APIKEYS
+              {{- if .Values.kyoo.existingSecret.name }}
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.kyoo.apikey.apikeyKey }}
-                  name: {{ .Values.kyoo.apikey.existingSecret }}
+                  key: {{ .Values.kyoo.existingSecret.key }}
+                  name: {{ .Values.kyoo.existingSecret.name }}
+              {{- else }}
+              value: {{ .Values.kyoo.apikey }}
+              {{- end }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -109,24 +123,28 @@ spec:
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_back.userKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_back.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_back.userKey }}
+                  name: {{ .Values.rabbitmq.kyoo_back.existingSecret }}
             - name: RABBITMQ_DEFAULT_PASS
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_back.passwordKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_back.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_back.passwordKey }}
+                  name: {{ .Values.rabbitmq.kyoo_back.existingSecret }}
             - name: RABBITMQ_HOST
-              value: {{ .Values.global.rabbitmq.host | quote }}
+              value: {{ .Values.rabbitmq.host | quote }}
             - name: RABBITMQ_PORT
-              value: {{ .Values.global.rabbitmq.port | quote }}
+              value: {{ .Values.rabbitmq.port | quote }}
             - name: MEILI_HOST
-              value: "{{ .Values.global.meilisearch.proto }}://{{ .Values.global.meilisearch.host }}:{{ .Values.global.meilisearch.port }}"
+              value: "{{ .Values.meilisearch.proto }}://{{ .Values.meilisearch.host }}:{{ .Values.meilisearch.port }}"
             - name: MEILI_MASTER_KEY
+              {{- if .Values.meilisearch.existingSecret.name }}
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.meilisearch.kyoo_back.masterkeyKey }}
-                  name: {{ .Values.global.meilisearch.kyoo_back.existingSecret }}
+                  key: {{ .Values.meilisearch.existingSecret.key }}
+                  name: {{ .Values.meilisearch.existingSecret.name }}
+              {{- else }}
+              value: {{ .Values.meilisearch.masterkey }}
+              {{- end }}
             {{- range $index, $provider := .Values.kyoo.oidc_providers }}
             - name: OIDC_{{ $provider.name | upper }}_NAME
               value: {{ $provider.name | quote }}
@@ -177,19 +195,18 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- with .Values.back.kyoo_back.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            - name: back
+              mountPath: {{ .Values.volumes.back.mountPath | quote }}
             {{- with .Values.back.kyoo_back.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with .Values.back.kyoo_back.extraContainers }}
+        {{- with .Values.back.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       volumes:
-        {{- with .Values.back.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        - name: back
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-back
         {{- with .Values.back.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -1,10 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.front.deploymentAnnotations) }}
+  {{- if and (.Values.global.podAnnotations) (.Values.front.deploymentAnnotations) }}
+    {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.front.deploymentAnnotations) }}
   annotations:
-    {{- range $key, $value := . }}
-    {{ $key }}: {{ $value | quote }}
+      {{- range $key, $value := . }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
   {{- end }}
   name: {{ include "kyoo.front.fullname" . }}
@@ -12,17 +14,21 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.front.name "name" .Values.front.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.front.replicaCount }}
+  strategy:
+    {{- toYaml .Values.front.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.front.name) | nindent 6 }}
   template:
     metadata:
+      {{- if and (.Values.global.podAnnotations) (.Values.front.podAnnotations) }}
       annotations:
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.front.podAnnotations) }}
-        {{- range $key, $value := . }}
-        {{ $key }}: {{ $value | quote }}
+          {{- range $key, $value := . }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.front.name "name" .Values.front.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.front.podLabels) }}
@@ -33,7 +39,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.securityContext }}
+      {{- with .Values.front.kyoo_front.containerSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -42,10 +48,12 @@ spec:
         - name: main
           image: {{ .Values.front.kyoo_front.image.repository | default (printf "%s/kyoo_front" .Values.global.image.repositoryBase) }}:{{ default (include "kyoo.defaultTag" .) .Values.front.kyoo_front.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+          {{- if .Values.front.kyoo_front.extraArgs }}
           args:
             {{- with .Values.front.kyoo_front.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           env:
             - name: KYOO_URL
               value: "http://{{ include "kyoo.back.fullname" . }}:5000"
@@ -76,7 +84,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.front.kyoo_front.extraContainers }}
+        {{- with .Values.front.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.front.extraInitContainers }}

--- a/chart/templates/matcher/deployment.yaml
+++ b/chart/templates/matcher/deployment.yaml
@@ -1,10 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.matcher.deploymentAnnotations) }}
+  {{- if and (.Values.global.podAnnotations) (.Values.matcher.deploymentAnnotations) }}
+    {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.matcher.deploymentAnnotations) }}
   annotations:
-    {{- range $key, $value := . }}
-    {{ $key }}: {{ $value | quote }}
+      {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
   {{- end }}
   name: {{ include "kyoo.matcher.fullname" . }}
@@ -12,17 +14,21 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.matcher.name "name" .Values.matcher.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.matcher.replicaCount }}
+  strategy:
+    {{- toYaml .Values.matcher.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.matcher.name) | nindent 6 }}
   template:
     metadata:
+      {{- if (and .Values.global.podAnnotations .Values.matcher.podAnnotations) }}
       annotations:
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.matcher.podAnnotations) }}
-        {{- range $key, $value := . }}
-        {{ $key }}: {{ $value | quote }}
+          {{- range $key, $value := . }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.matcher.name "name" .Values.matcher.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.matcher.podLabels) }}
@@ -33,7 +39,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.securityContext }}
+      {{- with .Values.matcher.kyoo_matcher.containerSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -48,43 +54,58 @@ spec:
             {{- end }}
           env:
             - name: KYOO_APIKEYS
+              {{- if .Values.kyoo.existingSecret.name }}
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.kyoo.apikey.apikeyKey }}
-                  name: {{ .Values.kyoo.apikey.existingSecret }}
+                  key: {{ .Values.kyoo.existingSecret.key }}
+                  name: {{ .Values.kyoo.existingSecret.name }}
+              {{- else }}
+              value: {{ .Values.kyoo.apikey }}
+              {{- end }}
             - name: KYOO_URL
               value: "http://{{ include "kyoo.back.fullname" . }}:5000"
             - name: LIBRARY_LANGUAGES
               value: {{ .Values.kyoo.languages | quote }}
             - name: THEMOVIEDB_APIKEY
+              {{- if .Values.kyoo.contentdatabase.tmdb.existingSecret.name }}
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.contentdatabase.tmdb.apikeyKey }}
-                  name: {{ .Values.contentdatabase.tmdb.existingSecret }}
+                  key: {{ .Values.kyoo.contentdatabase.tmdb.existingSecret.key }}
+                  name: {{ .Values.kyoo.contentdatabase.tmdb.existingSecret.name }}
+              {{- else }}
+              value: {{ .Values.kyoo.contentdatabase.tmdb.apikey }}
+              {{- end }}
+              {{- if .Values.kyoo.contentdatabase.tvdb.existingSecret.name }}
             - name: TVDB_APIKEY
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.contentdatabase.tvdb.apikeyKey }}
-                  name: {{ .Values.contentdatabase.tvdb.existingSecret }}
+                  key: {{ .Values.kyoo.contentdatabase.tvdb.existingSecret.keyApiKey }}
+                  name: {{ .Values.kyoo.contentdatabase.tvdb.existingSecret.name }}
             - name: TVDB_PIN
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.contentdatabase.tvdb.pinKey }}
-                  name: {{ .Values.contentdatabase.tvdb.existingSecret }}
+                  key: {{ .Values.kyoo.contentdatabase.tvdb.existingSecret.keyPinKey }}
+                  name: {{ .Values.kyoo.contentdatabase.tvdb.existingSecret.keyApiKey }}
+              {{- else }}
+            - name: TVDB_APIKEY
+              value: {{ .Values.kyoo.contentdatabase.tvdb.apikey }}
+            - name: TVDB_PIN
+              value: {{ .Values.kyoo.contentdatabase.tvdb.pin }}
+              {{- end }}
             - name: RABBITMQ_HOST
-              value: {{ .Values.global.rabbitmq.host | quote }}
+              value: {{ .Values.rabbitmq.host | quote }}
             - name: RABBITMQ_PORT
-              value: {{ .Values.global.rabbitmq.port | quote }}
+              value: {{ .Values.rabbitmq.port | quote }}
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_matcher.userKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_matcher.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_matcher.userKey }}
+                  name: {{ .Values.rabbitmq.kyoo_matcher.existingSecret }}
             - name: RABBITMQ_DEFAULT_PASS
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_matcher.passwordKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_matcher.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_matcher.passwordKey }}
+                  name: {{ .Values.rabbitmq.kyoo_matcher.existingSecret }}
             {{- with (concat .Values.global.extraEnv .Values.matcher.kyoo_matcher.extraEnv) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -108,7 +129,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.matcher.kyoo_matcher.extraContainers }}
+        {{- with .Values.matcher.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.matcher.extraInitContainers }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -1,10 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.scanner.deploymentAnnotations) }}
+  {{- if and (.Values.global.podAnnotations) (.Values.scanner.deploymentAnnotations) }}
+    {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.scanner.deploymentAnnotations) }}
   annotations:
-    {{- range $key, $value := . }}
-    {{ $key }}: {{ $value | quote }}
+      {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
   {{- end }}
   name: {{ include "kyoo.scanner.fullname" . }}
@@ -12,17 +14,21 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.scanner.name "name" .Values.scanner.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.scanner.replicaCount }}
+  strategy:
+    {{- toYaml .Values.scanner.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.scanner.name) | nindent 6 }}
   template:
     metadata:
+      {{- if (and .Values.global.podAnnotations .Values.scanner.podAnnotations) }}
       annotations:
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.scanner.podAnnotations) }}
-        {{- range $key, $value := . }}
-        {{ $key }}: {{ $value | quote }}
+          {{- range $key, $value := . }}
+            {{ $key }}: {{ $value | quote }}
+          {{- end }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.scanner.name "name" .Values.scanner.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.scanner.podLabels) }}
@@ -33,7 +39,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.securityContext }}
+      {{- with .Values.scanner.kyoo_scanner.containerSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -42,38 +48,44 @@ spec:
         - name: main
           image: {{ .Values.scanner.kyoo_scanner.image.repository | default (printf "%s/kyoo_scanner" .Values.global.image.repositoryBase) }}:{{ default (include "kyoo.defaultTag" .) .Values.scanner.kyoo_scanner.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+          {{- if .Values.scanner.kyoo_scanner.extraArgs }}
           args:
             {{- with .Values.scanner.kyoo_scanner.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           env:
             - name: SCANNER_LIBRARY_ROOT
-              value: {{ .Values.media.baseMountPath | quote }}
+              value: {{ .Values.volumes.media.mountPath | quote }}
             - name: LIBRARY_IGNORE_PATTERN
               value: {{ .Values.kyoo.libraryIgnorePattern | quote }}
             - name: KYOO_APIKEYS
+              {{- if .Values.kyoo.existingSecret.name }}
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.kyoo.apikey.apikeyKey }}
-                  name: {{ .Values.kyoo.apikey.existingSecret }}
+                  key: {{ .Values.kyoo.existingSecret.key }}
+                  name: {{ .Values.kyoo.existingSecret.name }}
+              {{- else }}
+              value: {{ .Values.kyoo.apikey }}
+              {{- end }}
             - name: KYOO_URL
               value: "http://{{ include "kyoo.back.fullname" . }}:5000"
             - name: LIBRARY_LANGUAGES
               value: {{ .Values.kyoo.languages | quote }}
             - name: RABBITMQ_HOST
-              value: {{ .Values.global.rabbitmq.host | quote }}
+              value: {{ .Values.rabbitmq.host | quote }}
             - name: RABBITMQ_PORT
-              value: {{ .Values.global.rabbitmq.port | quote }}
+              value: {{ .Values.rabbitmq.port | quote }}
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_scanner.userKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_scanner.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_scanner.userKey }}
+                  name: {{ .Values.rabbitmq.kyoo_scanner.existingSecret }}
             - name: RABBITMQ_DEFAULT_PASS
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.global.rabbitmq.kyoo_scanner.passwordKey }}
-                  name: {{ .Values.global.rabbitmq.kyoo_scanner.existingSecret }}
+                  key: {{ .Values.rabbitmq.kyoo_scanner.passwordKey }}
+                  name: {{ .Values.rabbitmq.kyoo_scanner.existingSecret }}
             {{- with (concat .Values.global.extraEnv .Values.scanner.kyoo_scanner.extraEnv) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -94,13 +106,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- with .Values.media.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            - name: media
+              mountPath: {{ .Values.volumes.media.mountPath }}
             {{- with .Values.scanner.kyoo_scanner.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with .Values.scanner.kyoo_scanner.extraContainers }}
+        {{- with .Values.scanner.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.scanner.extraInitContainers }}
@@ -108,9 +119,9 @@ spec:
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       volumes:
-        {{- with .Values.media.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        - name: media
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-media
         {{- with .Values.scanner.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -121,7 +121,11 @@ spec:
       volumes:
         - name: media
           persistentVolumeClaim:
+        {{- if .Values.volumes.media.existingClaim }}
+            claimName: {{ .Values.volumes.media.existingClaim }}
+        {{- else }}
             claimName: {{ .Release.Name }}-media
+        {{- end }}
         {{- with .Values.scanner.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{ if  .Values.kyoo.secrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{ .Values.kyoo.secrets.name}}
+    {{- if .Values.kyoo.secrets.labels }}
+    labels:
+        {{- toYaml .Values.kyoo.secrets.labels | nindent 8 }}
+    {{- end }}
+    {{- if .Values.kyoo.secrets.annotations }}
+    annotations:
+        {{- toYaml .Values.kyoo.secrets.annotations | nindent 8 }}
+    {{- end }}
+type: Opaque
+stringData:
+    {{- toYaml .Values.kyoo.secrets.data | nindent 4 }}
+{{ end }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -12,17 +12,21 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.transcoder.name "name" .Values.transcoder.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.transcoder.replicaCount }}
+  strategy:
+    {{- toYaml .Values.transcoder.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.transcoder.name) | nindent 6 }}
   template:
     metadata:
+      {{- if (and .Values.global.podAnnotations .Values.transcoder.podAnnotations) }}
       annotations:
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.transcoder.podAnnotations) }}
-        {{- range $key, $value := . }}
-        {{ $key }}: {{ $value | quote }}
+          {{- range $key, $value := . }}
+            {{ $key }}: {{ $value | quote }}
+          {{- end }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.transcoder.name "name" .Values.transcoder.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.transcoder.podLabels) }}
@@ -33,7 +37,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.securityContext }}
+      {{- with .Values.transcoder.kyoo_transcoder.containerSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -42,10 +46,12 @@ spec:
         - name: main
           image: {{ .Values.transcoder.kyoo_transcoder.image.repository | default (printf "%s/kyoo_transcoder" .Values.global.image.repositoryBase) }}:{{ default (include "kyoo.defaultTag" .) .Values.transcoder.kyoo_transcoder.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+          {{- if .Values.transcoder.kyoo_transcoder.extraArgs }}
           args:
             {{- with .Values.transcoder.kyoo_transcoder.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           env:
             - name: GOCODER_HWACCEL
               value: {{ .Values.kyoo.transcoderAcceleration | quote }}
@@ -58,7 +64,7 @@ spec:
             - name: GOCODER_PREFIX
               value: "/video"
             - name: GOCODER_SAFE_PATH
-              value: {{ .Values.media.baseMountPath | quote }}
+              value: {{ .Values.volumes.media.mountPath | quote }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -101,16 +107,14 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- with .Values.media.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.transcoder.kyoo_transcoder.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            - name: transcoder
+              mountPath: {{ .Values.volumes.transcoder.mountPath }}
+            - name: cache
+              mountPath: "/cache"
             {{- with .Values.transcoder.kyoo_transcoder.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with .Values.transcoder.kyoo_transcoder.extraContainers }}
+        {{- with .Values.transcoder.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.transcoder.extraInitContainers }}
@@ -118,12 +122,11 @@ spec:
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       volumes:
-        {{- with .Values.media.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.transcoder.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        - name: transcoder
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-transcoder
+        - name: cache
+          emptyDir: {}
         {{- with .Values.transcoder.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -107,6 +107,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: media
+              mountPath: {{ .Values.volumes.media.mountPath }}
             - name: transcoder
               mountPath: {{ .Values.volumes.transcoder.mountPath }}
             - name: cache
@@ -122,9 +124,20 @@ spec:
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       volumes:
+        - name: media
+          persistentVolumeClaim:
+        {{- if .Values.volumes.media.existingClaim }}
+            claimName: {{ .Values.volumes.media.existingClaim }}
+        {{- else }}
+            claimName: {{ .Release.Name }}-media
+        {{- end }}
         - name: transcoder
           persistentVolumeClaim:
+          {{- if .Values.volumes.transcoder.existingClaim }}
+            claimName: {{ .Values.volumes.transcoder.existingClaim }}
+          {{- else }}
             claimName: {{ .Release.Name }}-transcoder
+          {{- end }}
         - name: cache
           emptyDir: {}
         {{- with .Values.transcoder.extraVolumes }}

--- a/chart/templates/volumes.yaml
+++ b/chart/templates/volumes.yaml
@@ -1,0 +1,25 @@
+
+{{- range $key, $value := .Values.volumes }}
+  {{ if not $value.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $.Release.Name }}-{{ $key }}
+  {{- if $value.extraAnnotations }}
+  annotations:
+    {{- $value.extraAnnotations | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/part-of: {{ $.Release.Namespace }}
+    app.kubernetes.io/version: {{ include "kyoo.versionLabelValue" .context }}
+spec:
+    accessModes:
+        {{- toYaml $value.accessModes | nindent 6 }}
+    {{- if $value.storageClassName }}
+    storageClassName: {{ $value.storageClassName }}
+    {{- end }}
+    resources:
+    {{- $value.resources | toYaml | nindent 6 }}
+---
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,22 +12,6 @@ global:
   podAnnotations: {}
   podLabels: {}
   extraEnv: []
-
-  # kyoo connectivity & subchart settings for meilisearch
-  # subchart configuration can be found at .meilisearch
-  meilisearch:
-    proto: http
-    host: kyoo-meilisearch
-    port: 7700
-    # subchart specific settings
-    infra:
-      # subchart does not support specifying keyname.
-      # key must be named `MEILI_MASTER_KEY`
-      existingSecret: bigsecret
-    # kyoo_back workload specific settings
-    kyoo_back:
-      masterkeyKey: MEILI_MASTER_KEY
-      existingSecret: bigsecret
   # kyoo connectivity & subchart settings for postgres
   # subchart configuration can be found at .postgresql
   postgres:
@@ -37,7 +21,7 @@ global:
       # if updating be sure to also update .postgresql.auth.username
       user: kyoo_all
       passwordKey: postgres_password
-      existingSecret: bigsecret
+      existingSecret: kyoo-secrets
     # kyoo settings for connecting to kyoo_back database
     kyoo_back:
       host: kyoo-postgresql
@@ -47,12 +31,12 @@ global:
       kyoo_migrations:
         userKey: postgres_user
         passwordKey: postgres_password
-        existingSecret: bigsecret
+        existingSecret: kyoo-secrets
       # kyoo_back workload specific settings
       kyoo_back:
         userKey: postgres_user
         passwordKey: postgres_password
-        existingSecret: bigsecret
+        existingSecret: kyoo-secrets
     # kyoo settings for connecting to kyoo_transcoder database
     kyoo_transcoder:
       host: kyoo-postgresql
@@ -65,7 +49,7 @@ global:
       kyoo_transcoder:
         userKey: postgres_user
         passwordKey: postgres_password
-        existingSecret: bigsecret
+        existingSecret: kyoo-secrets
   # kyoo connectivity & subchart settings for rabbitmq
   # subchart configuration can be found at .rabbitmq
   rabbitmq:
@@ -78,27 +62,27 @@ global:
       # user must be manually aligned via rabbitmq.auth.user
       passwordKey: rabbitmq_password
       keyErlangCookie: rabbitmq_cookie
-      existingSecret: bigsecret
+      existingSecret: kyoo-secrets
     # kyoo_autosync workload specific settings
     kyoo_autosync:
       userKey: rabbitmq_user
       passwordKey: rabbitmq_password
-      existingSecret: bigsecret
+      existingSecret: kyoo-secrets
     # kyoo_back workload specific settings
     kyoo_back:
       userKey: rabbitmq_user
       passwordKey: rabbitmq_password
-      existingSecret: bigsecret
+      existingSecret: kyoo-secrets
     # kyoo_matcher workload specific settings
     kyoo_matcher:
       userKey: rabbitmq_user
       passwordKey: rabbitmq_password
-      existingSecret: bigsecret
+      existingSecret: kyoo-secrets
     # kyoo_scanner workload specific settings
     kyoo_scanner:
       userKey: rabbitmq_user
       passwordKey: rabbitmq_password
-      existingSecret: bigsecret
+      existingSecret: kyoo-secrets
 
 # kyoo application settings
 kyoo:
@@ -118,9 +102,12 @@ kyoo:
   # the preset used during transcode. faster means worst quality, you can probably use a slower preset with hwaccels
   # warning: using vaapi hwaccel disable presets (they are not supported).
   transcoderPreset: fast
-  apikey:
-    existingSecret: bigsecret
-    apikeyKey: kyoo_apikeys
+  apikey: apikeyforkyoo
+  # Required only if you want to use an existing secret
+  # Otherwise, leave it empty
+  existingSecret:
+    name: ""
+    key: ""
   # oidc_providers is a list of oidc providers that you want to use for authentication.
   # see the example below for how to configure an oidc provider.
   oidc_providers: []
@@ -134,34 +121,88 @@ kyoo:
     #   profileAddress: https://url-of-the-profile-endpoint-of-the-oidc-service.com/userinfo
     #   scope: "email openid profile"
     #   authMethod: ClientSecretBasic
+  # configures workloads that require access to contentdatabase
+  contentdatabase:
+    # TheMovieDB
+    tmdb:
+      apikey: "your_tmdb_apikey"
+      # Only required if you want to use an existing secret
+      existingSecret:
+        name: ""
+        key: ""
 
-# configures workloads that require access to media
-media:
-  # specifies the volumes to use
-  volumes:
-    - name: media
-      persistentVolumeClaim:
-        claimName: media
-  # specifies where to mount the volumes
-  # note that this should align with .media.baseMountPath
-  volumeMounts:
-    - mountPath: /data
-      name: media
-  # configures kyoo workloads to search
-  # note that this should align with .media.volumeMounts[].mountPath
-  baseMountPath: "/data"
+    # TVDatabase
+    tvdb:
+      apikey: "your_tvdb_apikey"
+      pin: "your_tvdb_pin"
+      # Only required if you want to use an existing secret
+      existingSecret:
+        name: ""
+        keyPinKey: ""
+        keyApiKey: ""
 
-# configures workloads that require access to contentdatabase
-contentdatabase:
-  # TheMovieDB
-  tmdb:
-    apikeyKey: tmdb_apikey
-    existingSecret: bigsecret
-  # TVDatabase
-  tvdb:
-    apikeyKey: tvdb_apikey
-    pinKey: tvdb_pin
-    existingSecret: bigsecret
+  # Configure applications related to kyoo
+  # - meilisearch
+  # - postgresql
+  # - rabbitmq
+  # Please refer to the subchart settings for more information
+  secrets:
+    enabled: true
+    labels: {}
+    annotations: {}
+    # Secret to be used for kyoo
+    # Should match with : 
+    # - .Values.meilisearch.infra.existingSecret
+    # - .Values.postgres.infra.existingSecret
+    # - .Values.rabbitmq.infra.existingSecret
+    name: kyoo-secrets
+    data:
+      MEILI_MASTER_KEY: barkLike8SuperDucks
+      postgres_user: kyoo_all
+      postgres_password: watchSomething4me
+      rabbitmq_user: kyoo_all
+      rabbitmq_password: youAreAmazing2
+      rabbitmq_cookie: mmmGoodCookie
+
+volumes:
+  media:
+    # If you want to use an existing PVC, set the name here
+    # otherwise, leave it empty
+    existingClaim: ""
+    # The name of the volume
+    # It will be prefixed with the release name (e.g kyoo-media)
+    name: "media"
+    accessModes:
+      - "ReadOnlyMany"
+      # Some CSI drivers do not support ReadOnlyMany (e.g. longhorn)
+      # If you are using such a driver, you can change this to ReadWriteMany
+      # - "ReadWriteMany"
+    # -- If empty, will use the default storage class
+    storageClassName: ""
+    resources:
+      requests:
+        storage: "1Gi"
+    mountPath: "/data"
+    extraAnnotations: {}
+  back:
+    existingClaim: ""
+    accessModes:
+      - "ReadWriteOnce"
+    resources:
+      requests:
+        storage: "2Gi"
+    extraAnnotations: {}
+    mountPath: "/metadata"
+  transcoder: 
+    existingClaim: ""
+    accessModes:
+      - "ReadWriteOnce"
+    storageClassName: ""
+    resources:
+      requests:
+        storage: "3Gi"
+    extraAnnotations: {}
+    mountPath: "/metadata"
 
 # autosync deployment configuration
 autosync:
@@ -180,6 +221,8 @@ autosync:
       tag: ~
   replicaCount: 1
   podLabels: {}
+  strategy:
+    type: Recreate
   deploymentAnnotations: {}
   podAnnotations: {}
   imagePullSecrets: []
@@ -194,6 +237,7 @@ autosync:
 
 # back deployment configuration
 back:
+  # TODO : LIMIT/REQUESTS
   name: back
   # kyoo_migrations init container configuration
   kyoo_migrations:
@@ -219,15 +263,10 @@ back:
     image:
       repository: ~
       tag: ~
-    volumeMounts:
-      - mountPath: /metadata
-        name: back-storage
-  volumes:
-    - name: back-storage
-      persistentVolumeClaim:
-        claimName: back-storage
   replicaCount: 1
   podLabels: {}
+  strategy:
+    type: Recreate
   deploymentAnnotations: {}
   podAnnotations: {}
   imagePullSecrets: []
@@ -261,6 +300,8 @@ front:
       tag: ~
   replicaCount: 1
   podLabels: {}
+  strategy:
+    type: Recreate
   deploymentAnnotations: {}
   podAnnotations: {}
   imagePullSecrets: []
@@ -299,6 +340,8 @@ matcher:
   # matcher does not support multiple replicas
   replicaCount: 1
   podLabels: {}
+  strategy:
+    type: Recreate
   deploymentAnnotations: {}
   podAnnotations: {}
   imagePullSecrets: []
@@ -329,6 +372,8 @@ scanner:
   # scanner does not support multiple replicas
   replicaCount: 1
   podLabels: {}
+  strategy:
+    type: Recreate
   deploymentAnnotations: {}
   podAnnotations: {}
   imagePullSecrets: []
@@ -342,6 +387,7 @@ scanner:
   extraVolumes: []
 
 # scanner deployment configuration
+# TODO: Configure PodAutoscaler (HPA) for transcoder
 transcoder:
   name: transcoder
   # kyoo_transcoder container configuration
@@ -356,19 +402,10 @@ transcoder:
     image:
       repository: ~
       tag: ~
-    volumeMounts:
-      - mountPath: /metadata
-        name: transcoder-storage
-      - mountPath: /cache
-        name: cache
-  volumes:
-    - name: transcoder-storage
-      persistentVolumeClaim:
-        claimName: transcoder-storage
-    - name: cache
-      emptyDir: {}
   replicaCount: 1
   podLabels: {}
+  strategy:
+    type: Recreate
   deploymentAnnotations: {}
   podAnnotations: {}
   imagePullSecrets: []
@@ -394,31 +431,40 @@ ingress:
   tls: false
   tlsSecret: ~
 
-# subchart settings
 meilisearch:
-  enabled: false
+  enabled: true
   environment:
     MEILI_ENV: production
   auth:
     # subchart does not support specifying keyname.
     # key must be named `MEILI_MASTER_KEY`
-    existingMasterKeySecret: "{{ .Values.global.meilisearch.infra.existingSecret }}"
+    # Should match kyoo secrets name (.Values.kyoo.secrets.name)
+    existingMasterKeySecret: "kyoo-secrets"
   persistence:
     enabled: true
     size: 3Gi
+  # kyoo connectivity & subchart settings for meilisearch
+  # subchart configuration can be found at .meilisearch
+  proto: http
+  host: kyoo-meilisearch
+  port: 7700
+  masterkey: ""
+  existingSecret:
+    name: kyoo-secrets
+    key: MEILI_MASTER_KEY
 
 # subchart settings
 postgresql:
-  enabled: false
+  enabled: true
   auth:
     # default user to be created by postgres subchart
     # subchart is unable to consume a secret for specifying user
     username: kyoo_all
-    existingSecret: "{{ .Values.global.postgres.infra.existingSecret }}"
+    existingSecret: kyoo-secrets
     secretKeys:
-      # set the postgres user password to the same as our user
-      adminPasswordKey: "{{ .Values.global.postgres.infra.passwordKey }}"
-      userPasswordKey: "{{ .Values.global.postgres.infra.passwordKey }}"
+      # Should match with .Values.kyoo.secrets.stringData.postgres_password
+      adminPasswordKey: "postgres_password"
+      userPasswordKey: "postgres_password"
   primary:
     # create databases, schemas, and set search_path
     initdb:
@@ -443,18 +489,51 @@ postgresql:
       size: 3Gi
 
 # subchart settings
+# kyoo connectivity & subchart settings for rabbitmq
+# subchart configuration can be found at .rabbitmq
 rabbitmq:
-  enabled: false
+  enabled: true
+  host: kyoo-rabbitmq
+  port: 5672
+    # vhost is not used yet https://github.com/zoriya/Kyoo/issues/537
+    # vhost: ""
+    # subchart specific settings
+  infra:
+    # user must be manually aligned via rabbitmq.auth.user
+    passwordKey: rabbitmq_password
+    keyErlangCookie: rabbitmq_cookie
+    existingSecret: kyoo-secrets
+  # kyoo_autosync workload specific settings
+  kyoo_autosync:
+    userKey: rabbitmq_user
+    passwordKey: rabbitmq_password
+    existingSecret: kyoo-secrets
+  # kyoo_back workload specific settings
+  kyoo_back:
+    userKey: rabbitmq_user
+    passwordKey: rabbitmq_password
+    existingSecret: kyoo-secrets
+    # kyoo_matcher workload specific settings
+  kyoo_matcher:
+    userKey: rabbitmq_user
+    passwordKey: rabbitmq_password
+    existingSecret: kyoo-secrets
+  # kyoo_scanner workload specific settings
+  kyoo_scanner:
+    userKey: rabbitmq_user
+    passwordKey: rabbitmq_password
+    existingSecret: kyoo-secrets
   auth:
     # default user to be created by rabbitmq subchart
     # subchart is unable to consume a secret for specifying user
     username: kyoo_all
-    existingPasswordSecret: "{{ .Values.global.rabbitmq.infra.existingSecret }}"
-    existingSecretPasswordKey: "{{ .Values.global.rabbitmq.infra.passwordKey }}"
-    existingErlangSecret: "{{ .Values.global.rabbitmq.infra.existingSecret }}"
-    existingSecretErlangKey: "{{ .Values.global.rabbitmq.infra.keyErlangCookie }}"
+    # Should match with .Values.kyoo.secrets.name
+    existingPasswordSecret: kyoo-secrets
+    existingSecretPasswordKey: rabbitmq_password
+    existingErlangSecret: kyoo-secrets
+    existingSecretErlangKey: rabbitmq_cookie
 
 # create extraObjects
-# create secret bigsecret
-# create pvc for each object
+# Create external PVs (.e.g. NFS to read videos from a NAS)
+# Use only if you have a specific need not covered by the values above
 extraObjects: []


### PR DESCRIPTION
Hello there 👋 

The changes proposed in this MR are :
- Re-structure the values so that the chart can be used OOB (without the need to add manifests in `extraObjects`). The modifications are similar to those usually seen in charts (e.g. bitnami) providing a way to either use a pre-existing secret, or generate it from the chart.
- Create volumes within the values

~~- Addition of a new component to the chart to support Ingress natively (without the need to support one-by-one ingress-controllers with their syntaxes).~~ (moved to #710)

Some minor additions: 
- Deletion of unused variables
- Added `strategy` field to define expected behavior during a rollout.
- Remove few `global` sections.

