### PR TITLE
Add HAProxy route configuration and update ingress settings

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -24,16 +24,9 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name: {{ include "kyoo.front.fullname" . }}
+              name: {{ .Release.Name }}-route
               port:
-                number: 8901
-        - path: "/api"
-          pathType: Prefix
-          backend:
-            service:
-              name: {{ include "kyoo.back.fullname" . }}
-              port:
-                number: 5000
+                number: 80
 {{- if .Values.ingress.tls }}
   tls:
   - hosts:

--- a/chart/templates/route/configMap.yaml
+++ b/chart/templates/route/configMap.yaml
@@ -1,0 +1,35 @@
+{{ if .Values.ingress.route.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.Release.Name }}-route-config
+data:
+  haproxy.cfg: |
+    global
+        log stdout format raw local0
+        maxconn 4096
+
+    defaults
+        log global
+        mode http
+        option httplog
+        option dontlognull
+        timeout connect 5000ms
+        timeout client 50000ms
+        timeout server 50000ms
+
+    frontend http-in
+        bind *:80
+        acl is_api path_beg /api
+        use_backend backend-api if is_api
+        default_backend backend-front
+
+    backend backend-api
+        option http-server-close
+        http-request set-path %[path,regsub(^/api/,/)]
+        server kyoo-back {{ include "kyoo.back.fullname" . }}:5000 check
+
+    backend backend-front
+        option http-server-close
+        server kyoo-front {{ include "kyoo.front.fullname" . }}:8901 check
+{{ end }}

--- a/chart/templates/route/deployment.yaml
+++ b/chart/templates/route/deployment.yaml
@@ -1,0 +1,60 @@
+{{ if .Values.ingress.route.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-route
+  {{- if or (.Values.ingress.route.annotations) (.Values.global.deploymentAnnotations) }}
+  annotations:
+    {{- if .Values.ingress.route.annotations }}
+      {{- toYaml .Values.ingress.route.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.deploymentAnnotations }}
+      {{- toYaml .Values.global.deploymentAnnotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app: {{ .Release.Name }}-route
+    {{- if .Values.ingress.route.labels }}
+      {{- with .Values.ingress.route.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.ingress.route.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-route
+      {{- if .Values.ingress.route.labels }}
+        {{- with .Values.ingress.route.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.ingress.route.annotations | nindent 8 }} 
+        {{- if .Values.global.podAnnotations }}
+          {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+        {{- end }}
+      labels:
+        app: {{ .Release.Name }}-route
+        {{- if .Values.ingress.route.labels }}
+          {{- with .Values.ingress.route.labels }}
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
+    spec:
+      containers:
+      - name: haproxy
+        image: {{ .Values.ingress.route.image.repository }}:{{ .Values.ingress.route.image.tag }}
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: haproxy-config
+          mountPath: /usr/local/etc/haproxy/haproxy.cfg
+          subPath: haproxy.cfg
+      volumes:
+      - name: haproxy-config
+        configMap:
+          name: {{ .Release.Name }}-route-config
+{{ end }}

--- a/chart/templates/route/service.yaml
+++ b/chart/templates/route/service.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.ingress.route.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-route
+  labels:
+    app: {{ .Release.Name }}-route
+spec:
+  selector:
+    app: {{ .Release.Name }}-route
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: {{ .Values.ingress.route.serviceType }}
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -386,13 +386,26 @@ transcoder:
   extraVolumes: []
 
 ingress:
-  enabled: false
+  enabled: true
   ingressClassName: ~
   annotations: {}
   extraAnnotations: {}
   host: kyoo.mydomain.com
   tls: false
   tlsSecret: ~
+  # Route is the component that will route the traffic to the correct service
+  # It is a requirement for the ingress to work (since we have rewrites rules that can't be done with ingress alone)
+  # This component may be replaced by APIGateway support in the future
+  route:
+    replicaCount: 1
+    annotations: {}
+    labels: {}
+    enabled: true
+    image:
+      repository: haproxy
+      tag: latest
+    port: 80
+    serviceType: ClusterIP
 
 # subchart settings
 meilisearch:


### PR DESCRIPTION
Related to #633

To solve the ingress problem for Kyoo, I propose the following modifications to add a new routing component. This component is only present to support url rewriting (without having to conform to the syntax of every existing ingress controller). Depending on Kyoo updates (notably with the proposed issue #653), this component is optional, since its sole purpose is to manage ingress traffic.

I suggest using HAProxy, which is currently the most flexible and easy-to-configure solution (Caddy was also a good candidate, but IMO is less permissive).

Note: This component may not be used by the GatewayAPI configuration (yet to be tested).
