### PR TITLE
rework volume management and add persistent volume claims

### DIFF
--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -177,19 +177,22 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- with .Values.back.kyoo_back.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            - name: back
+              mountPath: {{ .Values.volumes.back.mountPath | quote }}
             {{- with .Values.back.kyoo_back.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with .Values.back.kyoo_back.extraContainers }}
+        {{- with .Values.back.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       volumes:
-        {{- with .Values.back.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        - name: back
+          persistentVolumeClaim:
+          {{- if .Values.volumes.back.existingClaim }}
+            claimName: {{ .Values.volumes.back.existingClaim }}
+          {{- else }}
+            claimName: {{ .Release.Name }}-back
+          {{- end }}
         {{- with .Values.back.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- end }}
           env:
             - name: SCANNER_LIBRARY_ROOT
-              value: {{ .Values.media.baseMountPath | quote }}
+              value: {{ .Values.volumes.media.mountPath | quote }}
             - name: LIBRARY_IGNORE_PATTERN
               value: {{ .Values.kyoo.libraryIgnorePattern | quote }}
             - name: KYOO_APIKEYS
@@ -94,9 +94,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- with .Values.media.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            - name: media
+              mountPath: {{ .Values.volumes.media.mountPath }}
             {{- with .Values.scanner.kyoo_scanner.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -108,8 +107,12 @@ spec:
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       volumes:
-        {{- with .Values.media.volumes }}
-          {{- toYaml . | nindent 8 }}
+        - name: media
+          persistentVolumeClaim:
+        {{- if .Values.volumes.media.existingClaim }}
+            claimName: {{ .Values.volumes.media.existingClaim }}
+        {{- else }}
+            claimName: {{ .Release.Name }}-media
         {{- end }}
         {{- with .Values.scanner.extraVolumes }}
           {{- toYaml . | nindent 8 }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: GOCODER_PREFIX
               value: "/video"
             - name: GOCODER_SAFE_PATH
-              value: {{ .Values.media.baseMountPath | quote }}
+              value: {{ .Values.volumes.media.mountPath | quote }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -101,12 +101,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- with .Values.media.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.transcoder.kyoo_transcoder.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            - name: media
+              mountPath: {{ .Values.volumes.media.mountPath }}
+            - name: transcoder
+              mountPath: {{ .Values.volumes.transcoder.mountPath }}
+            - name: cache
+              mountPath: "/cache"
             {{- with .Values.transcoder.kyoo_transcoder.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -118,12 +118,22 @@ spec:
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       volumes:
-        {{- with .Values.media.volumes }}
-          {{- toYaml . | nindent 8 }}
+        - name: media
+          persistentVolumeClaim:
+        {{- if .Values.volumes.media.existingClaim }}
+            claimName: {{ .Values.volumes.media.existingClaim }}
+        {{- else }}
+            claimName: {{ .Release.Name }}-media
         {{- end }}
-        {{- with .Values.transcoder.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        - name: transcoder
+          persistentVolumeClaim:
+          {{- if .Values.volumes.transcoder.existingClaim }}
+            claimName: {{ .Values.volumes.transcoder.existingClaim }}
+          {{- else }}
+            claimName: {{ .Release.Name }}-transcoder
+          {{- end }}
+        - name: cache
+          emptyDir: {}
         {{- with .Values.transcoder.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/volumes.yaml
+++ b/chart/templates/volumes.yaml
@@ -1,0 +1,25 @@
+
+{{- range $key, $value := .Values.volumes }}
+  {{ if not $value.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $.Release.Name }}-{{ $key }}
+  {{- if $value.extraAnnotations }}
+  annotations:
+    {{- $value.extraAnnotations | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/part-of: {{ $.Release.Namespace }}
+    app.kubernetes.io/version: {{ include "kyoo.versionLabelValue" .context }}
+spec:
+    accessModes:
+        {{- toYaml $value.accessModes | nindent 6 }}
+    {{- if $value.storageClassName }}
+    storageClassName: {{ $value.storageClassName }}
+    {{- end }}
+    resources:
+    {{- $value.resources | toYaml | nindent 6 }}
+---
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -135,21 +135,45 @@ kyoo:
     #   scope: "email openid profile"
     #   authMethod: ClientSecretBasic
 
-# configures workloads that require access to media
-media:
-  # specifies the volumes to use
-  volumes:
-    - name: media
-      persistentVolumeClaim:
-        claimName: media
-  # specifies where to mount the volumes
-  # note that this should align with .media.baseMountPath
-  volumeMounts:
-    - mountPath: /data
-      name: media
-  # configures kyoo workloads to search
-  # note that this should align with .media.volumeMounts[].mountPath
-  baseMountPath: "/data"
+volumes:
+  media:
+    # If you want to use an existing PVC, set the name here
+    # otherwise, leave it empty
+    existingClaim: ""
+    # The name of the volume
+    # It will be prefixed with the release name (e.g kyoo-media)
+    name: "media"
+    accessModes:
+      - "ReadOnlyMany"
+      # Some CSI drivers do not support ReadOnlyMany (e.g. longhorn)
+      # If you are using such a driver, you can change this to ReadWriteMany
+      # - "ReadWriteMany"
+    # -- If empty, will use the default storage class
+    storageClassName: ""
+    resources:
+      requests:
+        storage: "1Gi"
+    mountPath: "/data"
+    extraAnnotations: {}
+  back:
+    existingClaim: ""
+    accessModes:
+      - "ReadWriteOnce"
+    resources:
+      requests:
+        storage: "2Gi"
+    extraAnnotations: {}
+    mountPath: "/metadata"
+  transcoder: 
+    existingClaim: ""
+    accessModes:
+      - "ReadWriteOnce"
+    storageClassName: ""
+    resources:
+      requests:
+        storage: "3Gi"
+    extraAnnotations: {}
+    mountPath: "/metadata"
 
 # configures workloads that require access to contentdatabase
 contentdatabase:
@@ -219,13 +243,6 @@ back:
     image:
       repository: ~
       tag: ~
-    volumeMounts:
-      - mountPath: /metadata
-        name: back-storage
-  volumes:
-    - name: back-storage
-      persistentVolumeClaim:
-        claimName: back-storage
   replicaCount: 1
   podLabels: {}
   deploymentAnnotations: {}
@@ -356,17 +373,6 @@ transcoder:
     image:
       repository: ~
       tag: ~
-    volumeMounts:
-      - mountPath: /metadata
-        name: transcoder-storage
-      - mountPath: /cache
-        name: cache
-  volumes:
-    - name: transcoder-storage
-      persistentVolumeClaim:
-        claimName: transcoder-storage
-    - name: cache
-      emptyDir: {}
   replicaCount: 1
   podLabels: {}
   deploymentAnnotations: {}


### PR DESCRIPTION
This PR changes the way volumes are generated and edited. 

Previously, these had to be generated manually by the user. With these changes, it is now possible to generate volumes from the Helm chart (while supporting the use of existing volumes).

These changes are essential to run Kyoo OOB (without generating additional resources).