### PR TITLE
fix: Helm Chart: map resources, livenessProbe and readinessProbe properties correctly in deployments

### DIFF
--- a/chart/templates/autosync/deployment.yaml
+++ b/chart/templates/autosync/deployment.yaml
@@ -66,15 +66,15 @@ spec:
             {{- end }}
           {{- with .Values.autosync.kyoo_autosync.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.autosync.kyoo_autosync.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.autosync.kyoo_autosync.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.autosync.kyoo_autosync.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.autosync.kyoo_autosync.resources }}
           resources:
-            {{- toYaml .Values.autosync.kyoo_autosync.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.autosync.kyoo_autosync.containerSecurityContext }}
           securityContext:

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -162,15 +162,15 @@ spec:
               protocol: TCP
           {{- with .Values.back.kyoo_back.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.back.kyoo_back.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.back.kyoo_back.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.back.kyoo_back.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.back.kyoo_back.resources }}
           resources:
-            {{- toYaml .Values.back.kyoo_back.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.back.kyoo_back.containerSecurityContext }}
           securityContext:

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -58,15 +58,15 @@ spec:
               protocol: TCP
           {{- with .Values.front.kyoo_front.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.front.kyoo_front.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.front.kyoo_front.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.front.kyoo_front.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.front.kyoo_front.resources }}
           resources:
-            {{- toYaml .Values.front.kyoo_front.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.front.kyoo_front.containerSecurityContext }}
           securityContext:

--- a/chart/templates/matcher/deployment.yaml
+++ b/chart/templates/matcher/deployment.yaml
@@ -90,15 +90,15 @@ spec:
             {{- end }}
           {{- with .Values.matcher.kyoo_matcher.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.matcher.kyoo_matcher.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.matcher.kyoo_matcher.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.matcher.kyoo_matcher.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.matcher.kyoo_matcher.resources }}
           resources:
-            {{- toYaml .Values.matcher.kyoo_matcher.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.matcher.kyoo_matcher.containerSecurityContext }}
           securityContext:

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -79,15 +79,15 @@ spec:
             {{- end }}
           {{- with .Values.scanner.kyoo_scanner.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.scanner.kyoo_scanner.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.scanner.kyoo_scanner.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.scanner.kyoo_scanner.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.scanner.kyoo_scanner.resources }}
           resources:
-            {{- toYaml .Values.scanner.kyoo_scanner.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.scanner.kyoo_scanner.containerSecurityContext }}
           securityContext:

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           {{- end }}
           {{- with .Values.transcoder.kyoo_transcoder.resources }}
           resources:
-            {{- toYaml .Values.transcoder.kyoo_transcoder.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.transcoder.kyoo_transcoder.containerSecurityContext }}
           securityContext:

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -86,11 +86,11 @@ spec:
               protocol: TCP
           {{- with .Values.transcoder.kyoo_transcoder.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.transcoder.kyoo_transcoder.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.transcoder.kyoo_transcoder.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.transcoder.kyoo_transcoder.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.transcoder.kyoo_transcoder.resources }}
           resources:


### PR DESCRIPTION
I was fiddling around with the resources property on the transcode deployment and I noticed that the chart would fail to apply.

I found a few other properties with the same issue so I took the liberty of adjusting them too. I haven't made a thorough search to find any other properties that have this issue.