### PR TITLE
fix: extraContainers

### DIFF
--- a/chart/templates/autosync/deployment.yaml
+++ b/chart/templates/autosync/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.autosync.kyoo_autosync.extraContainers }}
+        {{- with .Values.autosync.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.autosync.extraInitContainers }}

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -183,7 +183,7 @@ spec:
             {{- with .Values.back.kyoo_back.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with .Values.back.kyoo_back.extraContainers }}
+        {{- with .Values.back.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       volumes:

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.front.kyoo_front.extraContainers }}
+        {{- with .Values.front.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.front.extraInitContainers }}

--- a/chart/templates/matcher/deployment.yaml
+++ b/chart/templates/matcher/deployment.yaml
@@ -108,7 +108,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.matcher.kyoo_matcher.extraContainers }}
+        {{- with .Values.matcher.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.matcher.extraInitContainers }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -100,7 +100,7 @@ spec:
             {{- with .Values.scanner.kyoo_scanner.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with .Values.scanner.kyoo_scanner.extraContainers }}
+        {{- with .Values.scanner.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.scanner.extraInitContainers }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             {{- with .Values.transcoder.kyoo_transcoder.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- with .Values.transcoder.kyoo_transcoder.extraContainers }}
+        {{- with .Values.transcoder.extraContainers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.transcoder.extraInitContainers }}


### PR DESCRIPTION
There was a typo with extraContainers.  extraContainers is intended to be used at the pod level.  This fixes the typo in the templating.