### PR TITLE
chore: remove empty annotation field from being rendered

### DIFF
--- a/chart/templates/autosync/deployment.yaml
+++ b/chart/templates/autosync/deployment.yaml
@@ -17,12 +17,12 @@ spec:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.autosync.name) | nindent 6 }}
   template:
     metadata:
+      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.autosync.podAnnotations) }}
       annotations:
-        {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.autosync.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.autosync.name "name" .Values.autosync.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.autosync.podLabels) }}

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -17,12 +17,12 @@ spec:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.back.name) | nindent 6 }}
   template:
     metadata:
+      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.back.podAnnotations) }}
       annotations:
-        {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.back.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.back.name "name" .Values.back.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.back.podLabels) }}

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -17,12 +17,12 @@ spec:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.front.name) | nindent 6 }}
   template:
     metadata:
+      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.front.podAnnotations) }}
       annotations:
-        {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.front.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.front.name "name" .Values.front.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.front.podLabels) }}

--- a/chart/templates/matcher/deployment.yaml
+++ b/chart/templates/matcher/deployment.yaml
@@ -17,12 +17,12 @@ spec:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.matcher.name) | nindent 6 }}
   template:
     metadata:
+      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.matcher.podAnnotations) }}
       annotations:
-        {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.matcher.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.matcher.name "name" .Values.matcher.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.matcher.podLabels) }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -17,12 +17,12 @@ spec:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.scanner.name) | nindent 6 }}
   template:
     metadata:
+      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.scanner.podAnnotations) }}
       annotations:
-        {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.scanner.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.scanner.name "name" .Values.scanner.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.scanner.podLabels) }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -17,12 +17,12 @@ spec:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.transcoder.name) | nindent 6 }}
   template:
     metadata:
+      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.transcoder.podAnnotations) }}
       annotations:
-        {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.transcoder.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "kyoo.labels" (dict "context" . "component" .Values.transcoder.name "name" .Values.transcoder.name) | nindent 8 }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.transcoder.podLabels) }}


### PR DESCRIPTION
Before this change, running helm template would return an empty pod annotation `annotations:`.  Moving the line `{{- with` to before annotation solves this.  There is likely some logic inside of helm to avoid rendering blank fields but was unable to reason that until after this change.

*Before snippet*
```yaml
spec:
  template:
    metadata:
      annotations:
      labels:
        helm.sh/chart: kyoo-0.0.0
```

*After snippet*
```yaml
spec:
  template:
    metadata:
      labels:
        helm.sh/chart: kyoo-0.0.0
```

this has no functional impact