### PR TITLE
Remove autocomplete and autocapitalisation on server url and username fields

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -11,7 +11,7 @@
 		"build:mobile:dev": "yarn workspace mobile build:dev",
 		"update": "yarn workspace mobile update",
 		"lint": "biome lint .",
-		"lint:fix": "biome lint . --apply",
+		"lint:fix": "biome lint . --write",
 		"format": "biome format .",
 		"format:fix": "biome format . --write"
 	},

--- a/front/packages/ui/src/login/login.tsx
+++ b/front/packages/ui/src/login/login.tsx
@@ -55,7 +55,12 @@ export const LoginPage: QueryPage<{ apiUrl?: string; error?: string }> = ({
 			<H1>{t("login.login")}</H1>
 			<OidcLogin apiUrl={apiUrl} />
 			<P {...css({ paddingLeft: ts(1) })}>{t("login.username")}</P>
-			<Input autoComplete="username" variant="big" onChangeText={(value) => setUsername(value)} autoCapitalize='none'/>
+			<Input
+				autoComplete="username"
+				variant="big"
+				onChangeText={(value) => setUsername(value)}
+				autoCapitalize="none"
+			/>
 			<P {...css({ paddingLeft: ts(1) })}>{t("login.password")}</P>
 			<PasswordInput
 				autoComplete="password"

--- a/front/packages/ui/src/login/login.tsx
+++ b/front/packages/ui/src/login/login.tsx
@@ -55,7 +55,7 @@ export const LoginPage: QueryPage<{ apiUrl?: string; error?: string }> = ({
 			<H1>{t("login.login")}</H1>
 			<OidcLogin apiUrl={apiUrl} />
 			<P {...css({ paddingLeft: ts(1) })}>{t("login.username")}</P>
-			<Input autoComplete="username" variant="big" onChangeText={(value) => setUsername(value)} />
+			<Input autoComplete="username" variant="big" onChangeText={(value) => setUsername(value)} autoCapitalize='none'/>
 			<P {...css({ paddingLeft: ts(1) })}>{t("login.password")}</P>
 			<PasswordInput
 				autoComplete="password"

--- a/front/packages/ui/src/login/server-url.tsx
+++ b/front/packages/ui/src/login/server-url.tsx
@@ -63,7 +63,7 @@ export const ServerUrlPage: QueryPage = () => {
 		>
 			<H1>{t("login.server")}</H1>
 			<View {...css({ justifyContent: "center" })}>
-				<Input variant="big" onChangeText={setApiUrl} />
+				<Input variant="big" onChangeText={setApiUrl} autoCorrect={false} autoCapitalize='none' />
 				{!data && (
 					<P {...css({ color: (theme: Theme) => theme.colors.red, alignSelf: "center" })}>
 						{error?.errors[0] ?? t("misc.loading")}

--- a/front/packages/ui/src/login/server-url.tsx
+++ b/front/packages/ui/src/login/server-url.tsx
@@ -63,7 +63,7 @@ export const ServerUrlPage: QueryPage = () => {
 		>
 			<H1>{t("login.server")}</H1>
 			<View {...css({ justifyContent: "center" })}>
-				<Input variant="big" onChangeText={setApiUrl} autoCorrect={false} autoCapitalize='none' />
+				<Input variant="big" onChangeText={setApiUrl} autoCorrect={false} autoCapitalize="none" />
 				{!data && (
 					<P {...css({ color: (theme: Theme) => theme.colors.red, alignSelf: "center" })}>
 						{error?.errors[0] ?? t("misc.loading")}


### PR DESCRIPTION
While I've been testing the issue around not being able to connect to my http:// server with the app, I've found the autocomplete and autocapitalisation a bit annoying.

I thought it might be worth just adding in these to remove that behaviour as I don't think it's really something you want normally.

Basically: `kyoo.` would get autocorrected to `Kyoto.` which was super annoying! 😄 