### PR TITLE
Allow http:// support on android app

### DIFF
--- a/front/apps/mobile/app.config.ts
+++ b/front/apps/mobile/app.config.ts
@@ -70,7 +70,14 @@ const config: ExpoConfig = {
 		},
 	},
 	plugins: [
-		"expo-build-properties",
+		[
+			"expo-build-properties", 
+			{
+				android: {
+					usesCleartextTraffic: true
+				},
+			}
+		],
 		"expo-localization",
 		[
 			"react-native-video",

--- a/front/apps/mobile/app.config.ts
+++ b/front/apps/mobile/app.config.ts
@@ -71,12 +71,12 @@ const config: ExpoConfig = {
 	},
 	plugins: [
 		[
-			"expo-build-properties", 
+			"expo-build-properties",
 			{
 				android: {
-					usesCleartextTraffic: true
+					usesCleartextTraffic: true,
 				},
-			}
+			},
 		],
 		"expo-localization",
 		[


### PR DESCRIPTION
By default newer versions of android do not support http:// unless you specify in the application in the android manifest `android:usesCleartextTraffic=true`. To get this with an expo app, we just need to add it ton the app.config.ts file.