### PR TITLE
Create PVCs for back & transcoder

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -57,30 +57,10 @@ extraObjects:
   - kind: PersistentVolumeClaim
     apiVersion: v1
     metadata:
-      name: back-storage
-    spec:
-      accessModes:
-        - "ReadWriteOnce"
-      resources:
-        requests:
-          storage: "3Gi"
-  - kind: PersistentVolumeClaim
-    apiVersion: v1
-    metadata:
       name: media
     spec:
       accessModes:
         - "ReadOnlyMany"
-      resources:
-        requests:
-          storage: "3Gi"
-  - kind: PersistentVolumeClaim
-    apiVersion: v1
-    metadata:
-      name: transcoder-storage
-    spec:
-      accessModes:
-        - "ReadWriteOnce"
       resources:
         requests:
           storage: "3Gi"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -42,6 +42,14 @@ Create the name of the back service account to use
 {{- end -}}
 
 {{/*
+Create kyoo back-metadata name
+*/}}
+{{- define "kyoo.backmetadata.fullname" -}}
+{{- printf "%s-%s%s" (include "kyoo.fullname" .) .Values.back.name "metadata" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
 Create kyoo front name
 */}}
 {{- define "kyoo.front.fullname" -}}
@@ -111,4 +119,11 @@ Create the name of the transcoder service account to use
 {{- else -}}
     {{ default "default" .Values.transcoder.serviceAccount.name }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Create kyoo transcoder-metadata name
+*/}}
+{{- define "kyoo.transcodermetadata.fullname" -}}
+{{- printf "%s-%s%s" (include "kyoo.fullname" .) .Values.transcoder.name "metadata" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -177,6 +177,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.back.persistence.enabled }}
+            - name: backmetadata
+              mountPath: /metadata
+            {{- end }}
             {{- with .Values.back.kyoo_back.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -187,6 +191,17 @@ spec:
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       volumes:
+        {{- if .Values.back.persistence.enabled }}
+        {{- if .Values.back.persistence.existingClaim }}
+        - name: backmetadata
+          persistentVolumeClaim:
+            claimName: {{ .Values.back.persistence.existingClaim }}
+        {{- else }}
+        - name: backmetadata
+          persistentVolumeClaim:
+            claimName: {{ include "kyoo.backmetadata.fullname" . }}
+        {{- end }}
+        {{- end }}
         {{- with .Values.back.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/back/pvc.yaml
+++ b/chart/templates/back/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.back.persistence.enabled (not .Values.back.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kyoo.backmetadata.fullname" . }}
+  labels:
+    {{- include "kyoo.labels" (dict "context" . "component" .Values.back.name "name" .Values.back.name) | nindent 4 }}
+  {{- with (mergeOverwrite (deepCopy .Values.global.persistentVolumeClaimAnnotations) .Values.back.persistence.annotations) }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.back.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.back.persistence.size }}
+  {{- if .Values.back.persistence.storageClass }}
+  storageClassName: {{ .Values.back.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -104,6 +104,10 @@ spec:
             {{- with .Values.media.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.back.persistence.enabled }}
+            - name: transcodermetadata
+              mountPath: /metadata
+            {{- end }}
             {{- with .Values.transcoder.kyoo_transcoder.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -120,6 +124,17 @@ spec:
       volumes:
         {{- with .Values.media.volumes }}
           {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.transcoder.persistence.enabled }}
+        {{- if .Values.transcoder.persistence.existingClaim }}
+        - name: transcodermetadata
+          persistentVolumeClaim:
+            claimName: {{ .Values.transcoder.persistence.existingClaim }}
+        {{- else }}
+        - name: transcodermetadata
+          persistentVolumeClaim:
+            claimName: {{ include "kyoo.transcodermetadata.fullname" . }}
+        {{- end }}
         {{- end }}
         {{- with .Values.transcoder.volumes }}
           {{- toYaml . | nindent 8 }}

--- a/chart/templates/transcoder/pvc.yaml
+++ b/chart/templates/transcoder/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.transcoder.persistence.enabled (not .Values.transcoder.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kyoo.transcodermetadata.fullname" . }}
+  labels:
+    {{- include "kyoo.labels" (dict "context" . "component" .Values.transcoder.name "name" .Values.transcoder.name) | nindent 4 }}
+  {{- with (mergeOverwrite (deepCopy .Values.global.persistentVolumeClaimAnnotations) .Values.transcoder.persistence.annotations) }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.transcoder.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.transcoder.persistence.size }}
+  {{- if .Values.transcoder.persistence.storageClass }}
+  storageClassName: {{ .Values.transcoder.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,6 +9,7 @@ global:
     imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   deploymentAnnotations: {}
+  persistentVolumeClaimAnnotations: {}
   podAnnotations: {}
   podLabels: {}
   extraEnv: []
@@ -219,13 +220,8 @@ back:
     image:
       repository: ~
       tag: ~
-    volumeMounts:
-      - mountPath: /metadata
-        name: back-storage
-  volumes:
-    - name: back-storage
-      persistentVolumeClaim:
-        claimName: back-storage
+    volumeMounts: []
+  volumes: []
   replicaCount: 1
   podLabels: {}
   deploymentAnnotations: {}
@@ -243,6 +239,16 @@ back:
   extraContainers: []
   extraInitContainers: []
   extraVolumes: []
+  # backmetadata
+  # user profile pictures
+  persistence:
+    enabled: true
+    size: 3Gi
+    annotations: {}
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    existingClaim: ""
 
 # front deployment configuration
 front:
@@ -357,14 +363,9 @@ transcoder:
       repository: ~
       tag: ~
     volumeMounts:
-      - mountPath: /metadata
-        name: transcoder-storage
       - mountPath: /cache
         name: cache
   volumes:
-    - name: transcoder-storage
-      persistentVolumeClaim:
-        claimName: transcoder-storage
     - name: cache
       emptyDir: {}
   replicaCount: 1
@@ -384,6 +385,16 @@ transcoder:
   extraContainers: []
   extraInitContainers: []
   extraVolumes: []
+  # transcodermetadata
+  # thumbnail images & subtiles
+  persistence:
+    enabled: true
+    size: 3Gi
+    annotations: {}
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    existingClaim: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
Prior to this PR, users were expected to create the PVCs for back and transcoder beforehand.  These volumes are used for storing metadata for the respective service.

**Back Volume**
Stores user profile pictures
https://github.com/zoriya/Kyoo/blob/master/DIAGRAMS.md#back

** Transcoder Volume**
Stores thumbnail images & subtitles
https://github.com/zoriya/Kyoo/blob/master/DIAGRAMS.md#back

Users that have the previous helm chart deployed can leverage the previous volumes by adding the following helm values.  
```yaml
back:
  persistence:
    existingClaim:  back-storage
transcoder:
  persistence:
     existingClaim:  transcoder-storage
```

Note that the default accessModes is ReadWriteOnce.  Multiple replicas will requires ReadWriteMany in order to horizontally scale.  Currently Back and Transcoder do not support multiple replicas.