### PR TITLE
Allow specifying strategy for deployments

### DIFF
--- a/chart/templates/autosync/deployment.yaml
+++ b/chart/templates/autosync/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.autosync.name "name" .Values.autosync.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.autosync.replicaCount }}
+  {{- with .Values.autosync.updateStrategy }}
+  strategy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.autosync.name) | nindent 6 }}

--- a/chart/templates/autosync/deployment.yaml
+++ b/chart/templates/autosync/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   replicas: {{ .Values.autosync.replicaCount }}
   {{- with .Values.autosync.updateStrategy }}
-  strategy: {{ . }}
+  strategy: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   replicas: {{ .Values.back.replicaCount }}
   {{- with .Values.back.updateStrategy }}
-  strategy: {{ . }}
+  strategy: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.back.name "name" .Values.back.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.back.replicaCount }}
+  {{- with .Values.back.updateStrategy }}
+  strategy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.back.name) | nindent 6 }}

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.front.name "name" .Values.front.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.front.replicaCount }}
+  {{- with .Values.front.updateStrategy }}
+  strategy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.front.name) | nindent 6 }}

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   replicas: {{ .Values.front.replicaCount }}
   {{- with .Values.front.updateStrategy }}
-  strategy: {{ . }}
+  strategy: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/chart/templates/matcher/deployment.yaml
+++ b/chart/templates/matcher/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   replicas: {{ .Values.matcher.replicaCount }}
   {{- with .Values.matcher.updateStrategy }}
-  strategy: {{ . }}
+  strategy: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/chart/templates/matcher/deployment.yaml
+++ b/chart/templates/matcher/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.matcher.name "name" .Values.matcher.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.matcher.replicaCount }}
+  {{- with .Values.matcher.updateStrategy }}
+  strategy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.matcher.name) | nindent 6 }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.scanner.name "name" .Values.scanner.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.scanner.replicaCount }}
+  {{- with .Values.scanner.updateStrategy }}
+  strategy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.scanner.name) | nindent 6 }}

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   replicas: {{ .Values.scanner.replicaCount }}
   {{- with .Values.scanner.updateStrategy }}
-  strategy: {{ . }}
+  strategy: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- include "kyoo.labels" (dict "context" . "component" .Values.transcoder.name "name" .Values.transcoder.name) | nindent 4 }}
 spec:
   replicas: {{ .Values.transcoder.replicaCount }}
+  {{- with .Values.transcoder.updateStrategy }}
+  strategy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kyoo.selectorLabels" (dict "context" . "name" .Values.transcoder.name) | nindent 6 }}

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
 spec:
   replicas: {{ .Values.transcoder.replicaCount }}
   {{- with .Values.transcoder.updateStrategy }}
-  strategy: {{ . }}
+  strategy: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -229,7 +229,8 @@ back:
         claimName: back-storage
   replicaCount: 1
   # default to recreate for better user experience with ReadWriteOnce volumes  
-  updateStrategy: Recreate
+  updateStrategy:
+    type: Recreate
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}
@@ -375,7 +376,8 @@ transcoder:
       emptyDir: {}
   replicaCount: 1
   # default to recreate for better user experience with ReadWriteOnce volumes  
-  updateStrategy: Recreate
+  updateStrategy:
+    type: Recreate
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -179,6 +179,7 @@ autosync:
       repository: ~
       tag: ~
   replicaCount: 1
+  updateStrategy: ~
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}
@@ -227,6 +228,8 @@ back:
       persistentVolumeClaim:
         claimName: back-storage
   replicaCount: 1
+  # default to recreate for better user experience with ReadWriteOnce volumes  
+  updateStrategy: Recreate
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}
@@ -260,6 +263,7 @@ front:
       repository: ~
       tag: ~
   replicaCount: 1
+  updateStrategy: ~
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}
@@ -298,6 +302,7 @@ matcher:
       tag: ~
   # matcher does not support multiple replicas
   replicaCount: 1
+  updateStrategy: ~
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}
@@ -328,6 +333,7 @@ scanner:
       tag: ~
   # scanner does not support multiple replicas
   replicaCount: 1
+  updateStrategy: ~
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}
@@ -368,6 +374,8 @@ transcoder:
     - name: cache
       emptyDir: {}
   replicaCount: 1
+  # default to recreate for better user experience with ReadWriteOnce volumes  
+  updateStrategy: Recreate
   podLabels: {}
   deploymentAnnotations: {}
   podAnnotations: {}


### PR DESCRIPTION
This allows users to specify the update strategy for each deployment.  Setting default for Back and Transcoder to recreate to provide better user experience when using ReadWriteOnce volumes.