### PR TITLE
fix fmt sprintf in thumbnails.go

### DIFF
--- a/transcoder/src/thumbnails.go
+++ b/transcoder/src/thumbnails.go
@@ -66,7 +66,7 @@ func (s *MetadataService) ExtractThumbs(path string, sha string) (interface{}, e
 func extractThumbnail(path string, sha string) error {
 	defer printExecTime("extracting thumbnails for %s", path)()
 
-	os.MkdirAll(fmt.Sprintf("%s/%s", Settings.Metadata), 0o755)
+	os.MkdirAll(fmt.Sprintf("%s/%s", Settings.Metadata, sha), 0o755)
 
 	if _, err := os.Stat(getThumbPath(sha)); err == nil {
 		return nil


### PR DESCRIPTION
Forgotten variable, creates this folder:

![image](https://github.com/user-attachments/assets/65b8bbd9-8b92-40cc-87c5-422660464d09)
