### PR TITLE
Add prefix to back/auth/transcoder

### DIFF
--- a/auth/.env.example
+++ b/auth/.env.example
@@ -1,6 +1,9 @@
 # vi: ft=sh
 # shellcheck disable=SC2034
 
+# http route prefix (will listen to $KEIBI_PREFIX/users for example)
+KEIBI_PREFIX=""
+
 # Database things
 POSTGRES_USER=kyoo
 POSTGRES_PASSWORD=password

--- a/auth/config.go
+++ b/auth/config.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"os"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -13,6 +14,7 @@ import (
 )
 
 type Configuration struct {
+	Prefix          string
 	JwtPrivateKey   *rsa.PrivateKey
 	JwtPublicKey    *rsa.PublicKey
 	Issuer          string
@@ -51,6 +53,8 @@ func LoadConfiguration(db *dbc.Queries) (*Configuration, error) {
 			ret.JwtPublicKey = &key.PublicKey
 		}
 	}
+
+	ret.Prefix = os.Getenv("KEIBI_PREFIX")
 
 	if ret.JwtPrivateKey == nil {
 		ret.JwtPrivateKey, err = rsa.GenerateKey(rand.Reader, 4096)

--- a/auth/main.go
+++ b/auth/main.go
@@ -163,29 +163,30 @@ func main() {
 	}
 	h.config = conf
 
-	r := e.Group("")
+	g := e.Group(conf.Prefix)
+	r := e.Group(conf.Prefix)
 	r.Use(echojwt.WithConfig(echojwt.Config{
 		SigningMethod: "RS256",
 		SigningKey:    h.config.JwtPublicKey,
 	}))
 
-	e.GET("/health", h.CheckHealth)
+	g.GET("/health", h.CheckHealth)
 
 	r.GET("/users", h.ListUsers)
 	r.GET("/users/:id", h.GetUser)
 	r.GET("/users/me", h.GetMe)
 	r.DELETE("/users/:id", h.DeleteUser)
 	r.DELETE("/users/me", h.DeleteSelf)
-	e.POST("/users", h.Register)
+	g.POST("/users", h.Register)
 
-	e.POST("/sessions", h.Login)
+	g.POST("/sessions", h.Login)
 	r.DELETE("/sessions", h.Logout)
 	r.DELETE("/sessions/:id", h.Logout)
 
-	e.GET("/jwt", h.CreateJwt)
-	e.GET("/info", h.GetInfo)
+	g.GET("/jwt", h.CreateJwt)
+	g.GET("/info", h.GetInfo)
 
-	e.GET("/swagger/*", echoSwagger.WrapHandler)
+	g.GET("/swagger/*", echoSwagger.WrapHandler)
 
 	e.Logger.Fatal(e.Start(":4568"))
 }

--- a/back/.env.example
+++ b/back/.env.example
@@ -1,0 +1,5 @@
+# vi: ft=sh
+# shellcheck disable=SC2034
+
+# http route prefix (will listen to $KYOO_PREFIX/movie for example)
+KYOO_PREFIX=""

--- a/back/src/Kyoo.Core/Program.cs
+++ b/back/src/Kyoo.Core/Program.cs
@@ -17,7 +17,6 @@
 // along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using Kyoo.Abstractions.Controllers;
 using Kyoo.Authentication;
 using Kyoo.Core;
 using Kyoo.Core.Controllers;
@@ -28,6 +27,7 @@ using Kyoo.RabbitMq;
 using Kyoo.Swagger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
@@ -85,6 +85,7 @@ builder.ConfigureRabbitMq();
 WebApplication app = builder.Build();
 CoreModule.Services = app.Services;
 
+app.UsePathBase(new PathString(builder.Configuration.GetValue("KYOO_PREFIX", "")));
 app.UseHsts();
 app.UseKyooOpenApi();
 app.UseResponseCompression();

--- a/back/src/Kyoo.Meilisearch/Kyoo.Meilisearch.csproj
+++ b/back/src/Kyoo.Meilisearch/Kyoo.Meilisearch.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MeiliSearch" Version="0.15.5" />
+		<PackageReference Include="MeiliSearch" Version="0.15.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -37,9 +37,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
-      - "traefik.http.routers.api.middlewares=api-sp"
-      - "traefik.http.middlewares.api-sp.stripprefix.prefixes=/api"
-      - "traefik.http.middlewares.api-sp.stripprefix.forceSlash=false"
 
   migrations:
     build:
@@ -56,7 +53,7 @@ services:
     build: ./front
     restart: on-failure
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.front.rule=PathPrefix(`/`)"
@@ -86,7 +83,7 @@ services:
     env_file:
       - ./.env
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
     volumes:
       - ${LIBRARY_ROOT}:/video:ro
 
@@ -100,7 +97,7 @@ services:
     env_file:
       - ./.env
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
 
   autosync:
     build: ./autosync

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -69,12 +69,11 @@ services:
         condition: service_healthy
     env_file:
       - ./.env
+    environment:
+      - KEIBI_PREFIX=/auth
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.auth.rule=PathPrefix(`/auth/`)"
-      - "traefik.http.routers.auth.middlewares=auth-sp"
-      - "traefik.http.middlewares.auth-sp.stripprefix.prefixes=/auth"
-      - "traefik.http.middlewares.auth-sp.stripprefix.forceSlash=false"
     profiles:
       - "v5"
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -19,7 +19,8 @@ services:
     build: ./back
     restart: on-failure
     environment:
-      - TRANSCODER_URL=${TRANSCODER_URL:-http://transcoder:7666}
+      - TRANSCODER_URL=${TRANSCODER_URL:-http://transcoder:7666/video}
+      - KYOO_PREFIX=/api
     env_file:
       - ./.env
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,8 @@ services:
       - "5000:5000"
     restart: on-failure
     environment:
-      - TRANSCODER_URL=${TRANSCODER_URL:-http://transcoder:7666}
+      - TRANSCODER_URL=${TRANSCODER_URL:-http://transcoder:7666/video}
+      - KYOO_PREFIX=/api
     env_file:
       - ./.env
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -97,14 +97,13 @@ services:
       - "4568:4568"
     env_file:
       - ./.env
+    environment:
+      - KEIBI_PREFIX=/auth
     volumes:
       - ./auth:/app
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.auth.rule=PathPrefix(`/auth/`)"
-      - "traefik.http.routers.auth.middlewares=auth-sp"
-      - "traefik.http.middlewares.auth-sp.stripprefix.prefixes=/auth"
-      - "traefik.http.middlewares.auth-sp.stripprefix.forceSlash=false"
 
   scanner:
     build: ./scanner

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,9 +49,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
-      - "traefik.http.routers.api.middlewares=api-sp"
-      - "traefik.http.middlewares.api-sp.stripprefix.prefixes=/api"
-      - "traefik.http.middlewares.api-sp.stripprefix.forceSlash=false"
 
   migrations:
     build:
@@ -80,7 +77,7 @@ services:
       - "8081:8081"
     restart: on-failure
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.front.rule=PathPrefix(`/`)"
@@ -114,7 +111,7 @@ services:
     env_file:
       - ./.env
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
     volumes:
       - ${LIBRARY_ROOT}:/video:ro
 
@@ -128,7 +125,7 @@ services:
     env_file:
       - ./.env
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
 
   autosync:
     build: ./autosync

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
-      - "traefik.http.routers.api.middlewares=api-sp"
-      - "traefik.http.middlewares.api-sp.stripprefix.prefixes=/api"
-      - "traefik.http.middlewares.api-sp.stripprefix.forceSlash=false"
 
   migrations:
     image: ghcr.io/zoriya/kyoo_migrations:edge
@@ -55,7 +52,7 @@ services:
     image: ghcr.io/zoriya/kyoo_front:edge
     restart: unless-stopped
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.front.rule=PathPrefix(`/`)"
@@ -69,7 +66,7 @@ services:
     env_file:
       - ./.env
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
     volumes:
       - ${LIBRARY_ROOT}:/video:ro
 
@@ -83,7 +80,7 @@ services:
     env_file:
       - ./.env
     environment:
-      - KYOO_URL=${KYOO_URL:-http://back:5000}
+      - KYOO_URL=${KYOO_URL:-http://back:5000/api}
 
   autosync:
     image: ghcr.io/zoriya/kyoo_autosync:edge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     restart: unless-stopped
     cpus: 1.5
     environment:
-      - TRANSCODER_URL=${TRANSCODER_URL:-http://transcoder:7666}
+      - TRANSCODER_URL=${TRANSCODER_URL:-http://transcoder:7666/video}
+      - KYOO_PREFIX=/api
     env_file:
       - ./.env
     depends_on:

--- a/transcoder/main.go
+++ b/transcoder/main.go
@@ -308,18 +308,19 @@ func main() {
 		metadata:   metadata,
 	}
 
-	e.GET("/:path/direct", DirectStream)
-	e.GET("/:path/direct/:identifier", DirectStream)
-	e.GET("/:path/master.m3u8", h.GetMaster)
-	e.GET("/:path/:video/:quality/index.m3u8", h.GetVideoIndex)
-	e.GET("/:path/audio/:audio/index.m3u8", h.GetAudioIndex)
-	e.GET("/:path/:video/:quality/:chunk", h.GetVideoSegment)
-	e.GET("/:path/audio/:audio/:chunk", h.GetAudioSegment)
-	e.GET("/:path/info", h.GetInfo)
-	e.GET("/:path/thumbnails.png", h.GetThumbnails)
-	e.GET("/:path/thumbnails.vtt", h.GetThumbnailsVtt)
-	e.GET("/:path/attachment/:name", h.GetAttachment)
-	e.GET("/:path/subtitle/:name", h.GetSubtitle)
+	g := e.Group(src.Settings.RoutePrefix)
+	g.GET("/:path/direct", DirectStream)
+	g.GET("/:path/direct/:identifier", DirectStream)
+	g.GET("/:path/master.m3u8", h.GetMaster)
+	g.GET("/:path/:video/:quality/index.m3u8", h.GetVideoIndex)
+	g.GET("/:path/audio/:audio/index.m3u8", h.GetAudioIndex)
+	g.GET("/:path/:video/:quality/:chunk", h.GetVideoSegment)
+	g.GET("/:path/audio/:audio/:chunk", h.GetAudioSegment)
+	g.GET("/:path/info", h.GetInfo)
+	g.GET("/:path/thumbnails.png", h.GetThumbnails)
+	g.GET("/:path/thumbnails.vtt", h.GetThumbnailsVtt)
+	g.GET("/:path/attachment/:name", h.GetAttachment)
+	g.GET("/:path/subtitle/:name", h.GetSubtitle)
 
 	e.Logger.Fatal(e.Start(":7666"))
 }


### PR DESCRIPTION
This is a breaking change for downstream transcoder users that uses the `GOCODER_PREFIX` env var (ping @Arthi-chaud)

Closes #653 (will still need to add this option for v5's api, but no need to keep the issue around)