### PR TITLE
path update for helm charts

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.7.0"
+appVersion: "0.0.0"
 
 dependencies:
 - condition: meilisearch.enabled

--- a/chart/templates/back/deployment.yaml
+++ b/chart/templates/back/deployment.yaml
@@ -80,7 +80,9 @@ spec:
             {{- end }}
           env:
             - name: TRANSCODER_URL
-              value: "http://{{ include "kyoo.transcoder.fullname" . }}:7666"
+              value: "http://{{ include "kyoo.transcoder.fullname" . }}:7666/video"
+            - name: KYOO_PREFIX
+              value: "/api"
             - name: PUBLIC_URL
               value: {{ .Values.kyoo.address | quote }}
             - name: REQUIRE_ACCOUNT_VERIFICATION

--- a/chart/templates/front/deployment.yaml
+++ b/chart/templates/front/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             {{- end }}
           env:
             - name: KYOO_URL
-              value: "http://{{ include "kyoo.back.fullname" . }}:5000"
+              value: "http://{{ include "kyoo.back.fullname" . }}:5000/api"
             {{- with (concat .Values.global.extraEnv .Values.front.kyoo_front.extraEnv) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/templates/matcher/deployment.yaml
+++ b/chart/templates/matcher/deployment.yaml
@@ -57,7 +57,7 @@ spec:
                   key: {{ .Values.kyoo.apikey.apikeyKey }}
                   name: {{ .Values.kyoo.apikey.existingSecret }}
             - name: KYOO_URL
-              value: "http://{{ include "kyoo.back.fullname" . }}:5000"
+              value: "http://{{ include "kyoo.back.fullname" . }}:5000/api"
             - name: LIBRARY_LANGUAGES
               value: {{ .Values.kyoo.languages | quote }}
             - name: THEMOVIEDB_APIKEY

--- a/chart/templates/scanner/deployment.yaml
+++ b/chart/templates/scanner/deployment.yaml
@@ -61,7 +61,7 @@ spec:
                   key: {{ .Values.kyoo.apikey.apikeyKey }}
                   name: {{ .Values.kyoo.apikey.existingSecret }}
             - name: KYOO_URL
-              value: "http://{{ include "kyoo.back.fullname" . }}:5000"
+              value: "http://{{ include "kyoo.back.fullname" . }}:5000/api"
             - name: LIBRARY_LANGUAGES
               value: {{ .Values.kyoo.languages | quote }}
             - name: RABBITMQ_HOST


### PR DESCRIPTION
relates to https://github.com/zoriya/Kyoo/pull/747  updates the helm chart to specify paths and avoid the need for rewrite rules.