### PR TITLE
chart/sslmode templating

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -23,6 +23,8 @@ version: 0.0.0
 # It is recommended to use it with quotes.
 appVersion: "0.0.0"
 
+icon: https://raw.githubusercontent.com/zoriya/Kyoo/refs/heads/master/icons/icon.svg
+
 dependencies:
 - condition: meilisearch.enabled
   name: meilisearch

--- a/chart/templates/transcoder/deployment.yaml
+++ b/chart/templates/transcoder/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ .Values.global.postgres.kyoo_transcoder.port | quote }}
             - name: POSTGRES_SCHEMA
               value: {{ .Values.global.postgres.kyoo_transcoder.schema | quote  }}
+            - name: POSTGRES_SSLMODE
+              value: {{ .Values.global.postgres.kyoo_transcoder.sslmode | quote  }}
             {{- with (concat .Values.global.extraEnv .Values.transcoder.kyoo_transcoder.extraEnv) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,9 +59,11 @@ global:
       host: kyoo-postgresql
       port: 5432
       database: kyoo_transcoder
-      # POSTGRES_SCHEMA disabled means application will not create the schema
+      # schema disabled means application will not create the schema
       # and will instead use the user's search path
       schema: disabled
+      # sslmode valid options are 'require' or 'disable', 'prefer' is not supported
+      sslmode: disable
       # kyoo_transcoder workload specific settings
       kyoo_transcoder:
         userKey: postgres_user


### PR DESCRIPTION
Relates to #750  and #760

Allows users to specify the sslmode.  Default is to disable.  

If you are using a postgres operator such as CNPG/Zalando, they create postgres instances that require clients use SSL connections.  The underlying go client library does not support prefer and requires this to be explicitly set to disable or require.  https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters