### PR TITLE
[v5] Added support for storing images in S3-compatible object storage

### DIFF
--- a/api/src/controllers/images.ts
+++ b/api/src/controllers/images.ts
@@ -369,9 +369,9 @@ export async function isCached(
 		let lastModified: Date | undefined;
 		const stat = await getFile(filePath).stat();
 		try {
-			if (stat as S3Stats) {
+			if ((stat as S3Stats).lastModified) {
 				lastModified = (stat as S3Stats).lastModified;
-			} else if (stat as Stats) {
+			} else if ((stat as Stats).mtime) {
 				lastModified = (stat as Stats).mtime;
 			}
 		} catch {

--- a/api/src/controllers/images.ts
+++ b/api/src/controllers/images.ts
@@ -1,7 +1,7 @@
+import type { Stats } from "node:fs";
 import type { BunFile, S3File, S3Stats } from "bun";
 import { type SQL, and, eq, sql } from "drizzle-orm";
 import Elysia, { type Context, t } from "elysia";
-import type { Stats } from "node:fs";
 import { prefix } from "~/base";
 import { db } from "~/db";
 import {

--- a/api/src/controllers/images.ts
+++ b/api/src/controllers/images.ts
@@ -1,7 +1,7 @@
-import { stat } from "node:fs/promises";
-import type { BunFile } from "bun";
+import type { BunFile, S3File, S3Stats } from "bun";
 import { type SQL, and, eq, sql } from "drizzle-orm";
 import Elysia, { type Context, t } from "elysia";
+import type { Stats } from "node:fs";
 import { prefix } from "~/base";
 import { db } from "~/db";
 import {
@@ -15,6 +15,7 @@ import { sqlarr } from "~/db/utils";
 import { KError } from "~/models/error";
 import { bubble } from "~/models/examples";
 import { AcceptLanguage, isUuid, processLanguages } from "~/models/utils";
+import { getFile } from "~/utils";
 import { imageDir } from "./seed/images";
 
 function getRedirectToImageHandler({
@@ -98,7 +99,7 @@ export const imagesH = new Elysia({ tags: ["images"] })
 		"/images/:id",
 		async ({ params: { id }, query: { quality }, headers: reqHeaders }) => {
 			const path = `${imageDir}/${id}.${quality}.jpg`;
-			const file = Bun.file(path);
+			const file = getFile(path);
 
 			const etag = await generateETag(file);
 			if (await isCached(reqHeaders, etag, path))
@@ -366,8 +367,13 @@ export async function isCached(
 	if (headers["if-modified-since"]) {
 		const ifModifiedSince = headers["if-modified-since"];
 		let lastModified: Date | undefined;
+		const stat = await getFile(filePath).stat();
 		try {
-			lastModified = (await stat(filePath)).mtime;
+			if (stat as S3Stats) {
+				lastModified = (stat as S3Stats).lastModified;
+			} else if (stat as Stats) {
+				lastModified = (stat as Stats).mtime;
+			}
 		} catch {
 			/* empty */
 		}
@@ -382,7 +388,7 @@ export async function isCached(
 	return false;
 }
 
-export async function generateETag(file: BunFile) {
+export async function generateETag(file: BunFile | S3File) {
 	const hash = new Bun.CryptoHasher("md5");
 	hash.update(await file.arrayBuffer());
 

--- a/api/src/controllers/seed/images.ts
+++ b/api/src/controllers/seed/images.ts
@@ -1,18 +1,16 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import path from "node:path";
 import { encode } from "blurhash";
 import { type SQL, and, eq, is, lt, sql } from "drizzle-orm";
 import { PgColumn, type PgTable } from "drizzle-orm/pg-core";
+import path from "node:path";
 import { version } from "package.json";
 import type { PoolClient } from "pg";
 import sharp from "sharp";
 import { type Transaction, db } from "~/db";
 import { mqueue } from "~/db/schema/mqueue";
 import type { Image } from "~/models/utils";
+import { getFile } from "~/utils";
 
 export const imageDir = process.env.IMAGES_PATH ?? "./images";
-await mkdir(imageDir, { recursive: true });
-
 export const defaultBlurhash = "000000";
 
 type ImageTask = {
@@ -164,7 +162,9 @@ async function downloadImage(id: string, url: string): Promise<string> {
 	await Promise.all(
 		Object.entries(resolutions).map(async ([resolution, dimensions]) => {
 			const buffer = await image.clone().resize(dimensions.width).toBuffer();
-			await writeFile(path.join(imageDir, `${id}.${resolution}.jpg`), buffer);
+			const file = getFile(path.join(imageDir, `${id}.${resolution}.jpg`));
+
+			await Bun.write(file, buffer, { mode: 0o660 });
 		}),
 	);
 

--- a/api/src/controllers/seed/images.ts
+++ b/api/src/controllers/seed/images.ts
@@ -1,7 +1,7 @@
+import path from "node:path";
 import { encode } from "blurhash";
 import { type SQL, and, eq, is, lt, sql } from "drizzle-orm";
 import { PgColumn, type PgTable } from "drizzle-orm/pg-core";
-import path from "node:path";
 import { version } from "package.json";
 import type { PoolClient } from "pg";
 import sharp from "sharp";

--- a/api/src/utils.ts
+++ b/api/src/utils.ts
@@ -1,3 +1,5 @@
+import type { BunFile, S3File } from "bun";
+
 // remove indent in multi-line comments
 export const comment = (str: TemplateStringsArray, ...values: any[]) =>
 	str
@@ -14,3 +16,15 @@ export function getYear(date: string) {
 export type Prettify<T> = {
 	[K in keyof T]: Prettify<T[K]>;
 } & {};
+
+// Returns either a filesystem-backed file, or a S3-backed file,
+// depending on whether or not S3 environment variables are set.
+export function getFile(path: string): BunFile | S3File {
+	if ("S3_BUCKET" in process.env || "AWS_BUCKET" in process.env) {
+		// This will use a S3 client configured via environment variables.
+		// See https://bun.sh/docs/api/s3#credentials for more details.
+		return Bun.s3.file(path);
+	}
+
+	return Bun.file(path);
+}


### PR DESCRIPTION
As discussed on Discord [here](https://discord.com/channels/1216460898139635753/1216460898609401870/1362975074713469058), this adds support for storing images in S3-compatible object storage for the v5 implementation.

The benefit of using S3 here is that when multiple replicas of the service are running, they will now all have access to the same set of images. Returned values for `/images/:id` should now be consistent, regardless of which replica serves a response. In addition, images should only be downloaded and stored once for the entire service, instead of once per replica.

The environment variables that should be used to configure the S3 client are documented here: https://bun.sh/docs/api/s3#credentials