### PR TITLE
Support standard libpq environment variables for the API

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -36,4 +36,4 @@ jobs:
         working-directory: ./api
         run: bun test
         env:
-          POSTGRES_SERVER: localhost
+          PGHOST: localhost

--- a/api/.env.example
+++ b/api/.env.example
@@ -14,8 +14,18 @@ AUTH_SERVER=http://auth:4568
 
 IMAGES_PATH=./images
 
-POSTGRES_USER=kyoo
-POSTGRES_PASSWORD=password
-POSTGRES_DB=kyooDB
-POSTGRES_SERVER=postgres
-POSTGRES_PORT=5432
+# It is recommended to use the below PG environment variables when possible.
+POSTGRES_URL=postgres://user:password@hostname:port/dbname?sslmode=verify-full&sslrootcert=/path/to/server.crt&sslcert=/path/to/client.crt&sslkey=/path/to/client.key
+# The behavior of the below variables match what is documented here:
+# https://www.postgresql.org/docs/current/libpq-envars.html
+PGUSER=kyoo
+PGPASSWORD=password
+PGDB=kyooDB
+PGSERVER=postgres
+PGPORT=5432
+PGOPTIONS=-c search_path=kyoo,public
+PGPASSFILE=/my/password # Takes precedence over PGPASSWORD. New line characters are not trimmed.
+PGSSLMODE=verify-full
+PGSSLROOTCERT=/my/serving.crt
+PGSSLCERT=/my/client.crt
+PGSSLKEY=/my/client.key

--- a/api/.env.example
+++ b/api/.env.example
@@ -15,7 +15,7 @@ AUTH_SERVER=http://auth:4568
 IMAGES_PATH=./images
 
 # It is recommended to use the below PG environment variables when possible.
-POSTGRES_URL=postgres://user:password@hostname:port/dbname?sslmode=verify-full&sslrootcert=/path/to/server.crt&sslcert=/path/to/client.crt&sslkey=/path/to/client.key
+# POSTGRES_URL=postgres://user:password@hostname:port/dbname?sslmode=verify-full&sslrootcert=/path/to/server.crt&sslcert=/path/to/client.crt&sslkey=/path/to/client.key
 # The behavior of the below variables match what is documented here:
 # https://www.postgresql.org/docs/current/libpq-envars.html
 PGUSER=kyoo
@@ -23,9 +23,9 @@ PGPASSWORD=password
 PGDB=kyooDB
 PGSERVER=postgres
 PGPORT=5432
-PGOPTIONS=-c search_path=kyoo,public
-PGPASSFILE=/my/password # Takes precedence over PGPASSWORD. New line characters are not trimmed.
-PGSSLMODE=verify-full
-PGSSLROOTCERT=/my/serving.crt
-PGSSLCERT=/my/client.crt
-PGSSLKEY=/my/client.key
+# PGOPTIONS=-c search_path=kyoo,public
+# PGPASSFILE=/my/password # Takes precedence over PGPASSWORD. New line characters are not trimmed.
+# PGSSLMODE=verify-full
+# PGSSLROOTCERT=/my/serving.crt
+# PGSSLCERT=/my/client.crt
+# PGSSLKEY=/my/client.key

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -1,19 +1,162 @@
+import dns from "node:dns";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import tls, { type ConnectionOptions } from "node:tls";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate as migrateDb } from "drizzle-orm/node-postgres/migrator";
+import type { PoolConfig } from "pg";
 import * as schema from "./schema";
 
-const dbConfig = {
-	user: process.env.POSTGRES_USER ?? "kyoo",
-	password: process.env.POSTGRES_PASSWORD ?? "password",
-	database: process.env.POSTGRES_DB ?? "kyoo",
-	host: process.env.POSTGRES_SERVER ?? "postgres",
-	port: Number(process.env.POSTGRES_PORT) || 5432,
-	ssl: false,
-};
+async function getPostgresConfig(): Promise<PoolConfig> {
+	const config: PoolConfig = {
+		connectionString: process.env.POSTGRES_URL,
+		host: process.env.PGHOST ?? process.env.POSTGRES_SERVER ?? "postgres",
+		port: Number(process.env.PGPORT ?? process.env.POSTGRES_PORT) || 5432,
+		database: process.env.PGDATABASE ?? process.env.POSTGRES_DB ?? "kyoo",
+		user: process.env.PGUSER ?? process.env.POSTGRES_USER ?? "kyoo",
+		password:
+			process.env.PGPASSWORD ?? process.env.POSTGRES_PASSWORD ?? "password",
+		options: process.env.PGOPTIONS,
+		application_name: process.env.PGAPPNAME ?? "kyoo",
+	};
+
+	// Due to an upstream bug, if `ssl` is not falsey, an SSL connection will always be attempted. This means
+	// that non-SSL connection options under `ssl` (which is incorrectly named) cannot be set unless SSL is enabled.
+	if (!process.env.PGSSLMODE || process.env.PGSSLMODE === "disable")
+		return config;
+
+	// Despite this field's name, it is used to configure everything below the application layer.
+	const ssl: ConnectionOptions = {
+		timeout:
+			(process.env.PGCONNECT_TIMEOUT &&
+				Number(process.env.PGCONNECT_TIMEOUT)) ||
+			undefined,
+		minVersion: process.env.PGSSLMINPROTOCOLVERSION as tls.SecureVersion,
+		maxVersion: process.env.PGSSLMAXPROTOCOLVERSION as tls.SecureVersion,
+	};
+
+	// If the config is a hostname and the host address is set, use a custom lookup function
+	if (net.isIP(config.host ?? "") === 0 && process.env.PGHOSTADDR) {
+		const ipVersion = net.isIP(process.env.PGHOSTADDR);
+		if (ipVersion === 0) {
+			throw new Error(
+				`PGHOSTADDR is not a valid IP address: ${process.env.PGHOSTADDR}`,
+			);
+		}
+
+		(config.ssl as ConnectionOptions).lookup = (
+			hostname: string,
+			options: dns.LookupOptions,
+			callback: (
+				err: NodeJS.ErrnoException | null,
+				address: string | dns.LookupAddress[],
+				family?: number,
+			) => void,
+		) => {
+			if (hostname !== config.host) {
+				dns.lookup(hostname, options, callback);
+				return;
+			}
+
+			return callback(null, process.env.PGHOSTADDR as string, ipVersion);
+		};
+	}
+
+	if (process.env.PGPASSFILE || !process.env.PGPASSWORD) {
+		const file = Bun.file(
+			process.env.PGPASSFILE ?? path.join(os.homedir(), ".pgpass"),
+		);
+		if (await file.exists()) {
+			config.password = await file.text();
+		}
+	}
+
+	// Handle https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT
+	if (process.env.PGSSLROOTCERT === "system") {
+		// Bun does not currently support getCACertificates. Until this is supported,
+		// use the closest equivalent, which loads the bundled CA certs rather than the system CA certs.
+		// ssl.ca = tls.getCACertificates("system");
+		ssl.ca = [...tls.rootCertificates];
+
+		if (!process.env.PGSSLMODE) {
+			process.env.PGSSLMODE = "verify-full";
+		}
+		if (process.env.PGSSLMODE && process.env.PGSSLMODE !== "verify-full") {
+			throw new Error(
+				"PGSSLROOTCERT=system is only supported with PGSSLMODE=verify-full. See Postgres docs for details.",
+			);
+		}
+	} else {
+		const file = Bun.file(
+			process.env.PGSSLROOTCERT ??
+				path.join(os.homedir(), ".postgresql", "root.crt"),
+		);
+		if (await file.exists()) {
+			ssl.ca = await file.text();
+		}
+	}
+
+	// TODO support CRLs. This requires verifying the contents against symlink hashes prepared by `openssl c_rehash`,
+	// as described in the postgres docs for PGSSLCRL and PGSSLCRLDIR. This isn't terribly common, so it's not currently
+	// implemented.
+
+	let file = Bun.file(
+		process.env.PGSSLCERT ??
+			path.join(os.homedir(), ".postgresql", "postgresql.crt"),
+	);
+	if (await file.exists()) {
+		ssl.cert = await file.text();
+	}
+
+	file = Bun.file(
+		process.env.PGSSLKEY ??
+			path.join(os.homedir(), ".postgresql", "postgresql.key"),
+	);
+	if (await file.exists()) {
+		ssl.key = [
+			{
+				pem: await file.text(),
+			},
+		];
+	}
+
+	if (process.env.PGSSLMODE) {
+		switch (process.env.PGSSLMODE) {
+			// Disable is handled above, gateing the configurating of any SSL options.
+			// Allow and prefer are not currently supported. Supporting them would require
+			// either mulitiple attempted connections, or changes upstream to the postgres driver.
+			case "require":
+				ssl.checkServerIdentity = (_host, _cert) => {
+					return undefined;
+				};
+				break;
+			case "verify-ca":
+				ssl.rejectUnauthorized = true;
+				ssl.checkServerIdentity = (_host, _cert) => {
+					return undefined;
+				};
+				break;
+			case "verify-full":
+				ssl.rejectUnauthorized = true;
+				break;
+			default:
+				ssl.rejectUnauthorized = false;
+		}
+	}
+
+	if (process.env.PGSSLSNI !== "0") {
+		ssl.servername = config.host;
+	}
+
+	config.ssl = ssl;
+	return config;
+}
+
 export const db = drizzle({
 	schema,
-	connection: dbConfig,
+	connection: await getPostgresConfig(),
 	casing: "snake_case",
 });
 
@@ -22,14 +165,14 @@ export const migrate = async () => {
 		sql.raw(`
 			create extension if not exists pg_trgm;
 			SET pg_trgm.word_similarity_threshold = 0.4;
-			ALTER DATABASE "${dbConfig.database}" SET pg_trgm.word_similarity_threshold = 0.4;
+			ALTER DATABASE "${(await getPostgresConfig()).database}" SET pg_trgm.word_similarity_threshold = 0.4;
 		`),
 	);
 	await migrateDb(db, {
 		migrationsSchema: "kyoo",
 		migrationsFolder: "./drizzle",
 	});
-	console.log(`Database ${dbConfig.database} migrated!`);
+	console.log(`Database ${(await getPostgresConfig()).database} migrated!`);
 };
 
 export type Transaction =


### PR DESCRIPTION
The implements standard libpq environment variables documented [here](https://www.postgresql.org/docs/current/libpq-envars.html). The current environment variables are now supported:
* `POSTGRES_URL` - nonstandard. Used to set the connection string. Be aware that configuration values provided via the connection string are limited to what the Postgres driver's parser logic supports.
* `PGHOSTADDR`
* `PGHOST` - already supported, but renamed while retaining support for the current env var name.
* `PGPORT` - already supported, but renamed while retaining support for the current env var name.
* `PGDATABASE` - already supported, but renamed while retaining support for the current env var name.
* `PGUSER` - already supported, but renamed while retaining support for the current env var name.
* `PGPASSWORD` - already supported, but renamed while retaining support for the current env var name.
* `PGOPTIONS`
* `PGCONNECT_TIMEOUT`
* `PGPASSFILE`
* `PGSSLMODE` - This differs from the spec a bit. If anything other than `disable` is specified, only TLS will be attempted. In other words, `allow` and `prefer` will not attempt a non-TLS connection. Supporting this would require quite a bit of extra logic that attempts to create connections with and without TLS, and probably isn't desired.
* `PGSSLROOTCERT` - This differs from the spec when `system` is specified. It looks like Bun does not support `tls.getCACertificates`, so when a value of `system` is specified, the bundled root CA certs are used instead of the system certs.
* `PGSSLCERT`
* `PGSSLKEY`
* `PGSSLSNI`
* `PGSSLMINPROTOCOLVERSION`
* `PGSSLMAXPROTOCOLVERSION`

With this PR, the following postgres features are now supported (when configured):
* Connection via TLS with a Postgres serving cert that is not publicly trusted
* Postgres authentication via client certificate (mTLS), removing the need for long-lived passwords
* Connecting to a postgres server without DNS resolution
* Lowering or raising the connection timeout, allowing for quickly determining when the DB is offline, or allowing more time for slower networks
* Loading a password via a file instead of an env var
* Setting connection options
* Configuring the postgres connection via a single env var (with some limitations)