### PR TITLE
Support standard libpq environment variables for Auth service

### DIFF
--- a/.github/workflows/auth-hurl.yml
+++ b/.github/workflows/auth-hurl.yml
@@ -51,7 +51,7 @@ jobs:
           wget --retry-connrefused --retry-on-http-error=502 http://localhost:4568/health
           hurl --error-format long --variable host=http://localhost:4568 tests/*
         env:
-          POSTGRES_SERVER: localhost
+          PGHOST: localhost
           FIRST_USER_CLAIMS: '{"permissions": ["users.read"]}'
           KEIBI_APIKEY_HURL: 1234apikey
           KEIBI_APIKEY_HURL_CLAIMS: '{"permissions": ["apikeys.write", "apikeys.read"]}'

--- a/api/.env.example
+++ b/api/.env.example
@@ -20,8 +20,8 @@ IMAGES_PATH=./images
 # https://www.postgresql.org/docs/current/libpq-envars.html
 PGUSER=kyoo
 PGPASSWORD=password
-PGDB=kyooDB
-PGSERVER=postgres
+PGDATABASE=kyooDB
+PGHOST=postgres
 PGPORT=5432
 # PGOPTIONS=-c search_path=kyoo,public
 # PGPASSFILE=/my/password # Takes precedence over PGPASSWORD. New line characters are not trimmed.

--- a/auth/.env.example
+++ b/auth/.env.example
@@ -29,11 +29,24 @@ PUBLIC_URL=http://localhost:8901
 # KEIBI_APIKEY_$YOURNAME_CLAIMS='{"permissions": ["users.read"]}'
 
 # Database things
-POSTGRES_USER=kyoo
-POSTGRES_PASSWORD=password
-POSTGRES_DB=kyoo
-POSTGRES_SERVER=postgres
-POSTGRES_PORT=5432
+# It is recommended to use the below PG environment variables when possible.
+# POSTGRES_URL=postgres://user:password@hostname:port/dbname?sslmode=verify-full&sslrootcert=/path/to/server.crt&sslcert=/path/to/client.crt&sslkey=/path/to/client.key
+
+# The behavior of the below variables match what is documented here:
+# https://www.postgresql.org/docs/current/libpq-envars.html
+# The "source of truth" for what variables are supported is documented here:
+# https://github.com/jackc/pgx/blob/master/pgconn/config.go#L190-L205
+PGUSER=kyoo
+PGPASSWORD=password
+PGDATABASE=kyoo
+PGHOST=postgres
+PGPORT=5432
+# PGPASSFILE=/my/password
+# PGSSLMODE=verify-full
+# PGSSLROOTCERT=/my/serving.crt
+# PGSSLCERT=/my/client.crt
+# PGSSLKEY=/my/client.key
+
 # Default is keibi, you can specify "disabled" to use the default search_path of the user.
 #  If this is not "disabled", the schema will be created (if it does not exists) and
 #  the search_path of the user will be ignored (only the schema specified will be used).


### PR DESCRIPTION
Follow up to https://github.com/zoriya/Kyoo/pull/899. This uses the pgx library to parse a connection string and env vars. The pgx library supports enough env vars for TLS connections, and TLS auth (on top of the currently supported vars).