### PR TITLE
Support standard libpq environment variables for the Backend service

### DIFF
--- a/back/.env.example
+++ b/back/.env.example
@@ -3,3 +3,18 @@
 
 # http route prefix (will listen to $KYOO_PREFIX/movie for example)
 KYOO_PREFIX=""
+
+# POSTGRES_URL=postgres://user:password@hostname:port/dbname?sslmode=verify-full&sslrootcert=/path/to/server.crt&sslcert=/path/to/client.crt&sslkey=/path/to/client.key
+# The behavior of the below variables match what is documented here:
+# https://www.postgresql.org/docs/current/libpq-envars.html
+PGUSER=kyoo
+PGPASSWORD=password
+PGDB=kyooDB
+PGSERVER=postgres
+PGPORT=5432
+# PGOPTIONS=-c search_path=kyoo,public
+# PGPASSFILE=/my/password # Takes precedence over PGPASSWORD. New line characters are not trimmed.
+# PGSSLMODE=verify-full
+# PGSSLROOTCERT=/my/serving.crt
+# PGSSLCERT=/my/client.crt
+# PGSSLKEY=/my/client.key


### PR DESCRIPTION
Follow up to https://github.com/zoriya/Kyoo/pull/899. This uses the Npgsql library to parse a connection string and env vars. Support should be pretty extensive, see details [here](https://www.npgsql.org/doc/connection-string-parameters.html). This is backwards compatible with current vars, and continues to use the same default values.