### PR TITLE
Support POSTGRES_URL environment variable for the Transcoder service

### DIFF
--- a/transcoder/.env.example
+++ b/transcoder/.env.example
@@ -21,6 +21,8 @@ GOCODER_VAAPI_RENDERER="/dev/dri/renderD128"
 GOCODER_QSV_RENDERER="/dev/dri/renderD128"
 
 # Database things
+# Setting this ignores the below connection variables and overrides any default values
+# POSTGRES_URL=postgres://user:password@host:port/dbname?sslmode=disable
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=

--- a/transcoder/src/metadata.go
+++ b/transcoder/src/metadata.go
@@ -23,20 +23,25 @@ type MetadataService struct {
 }
 
 func NewMetadataService() (*MetadataService, error) {
-	con := fmt.Sprintf(
-		"postgresql://%v:%v@%v:%v/%v?application_name=gocoder&sslmode=%s",
-		url.QueryEscape(os.Getenv("POSTGRES_USER")),
-		url.QueryEscape(os.Getenv("POSTGRES_PASSWORD")),
-		url.QueryEscape(os.Getenv("POSTGRES_SERVER")),
-		url.QueryEscape(os.Getenv("POSTGRES_PORT")),
-		url.QueryEscape(os.Getenv("POSTGRES_DB")),
-		url.QueryEscape(GetEnvOr("POSTGRES_SSLMODE", "disable")),
-	)
 	schema := GetEnvOr("POSTGRES_SCHEMA", "gocoder")
-	if schema != "disabled" {
-		con = fmt.Sprintf("%s&search_path=%s", con, url.QueryEscape(schema))
+
+	connectionString := os.Getenv("POSTGRES_URL")
+	if connectionString == "" {
+		connectionString = fmt.Sprintf(
+			"postgresql://%v:%v@%v:%v/%v?application_name=gocoder&sslmode=%s",
+			url.QueryEscape(os.Getenv("POSTGRES_USER")),
+			url.QueryEscape(os.Getenv("POSTGRES_PASSWORD")),
+			url.QueryEscape(os.Getenv("POSTGRES_SERVER")),
+			url.QueryEscape(os.Getenv("POSTGRES_PORT")),
+			url.QueryEscape(os.Getenv("POSTGRES_DB")),
+			url.QueryEscape(GetEnvOr("POSTGRES_SSLMODE", "disable")),
+		)
+		if schema != "disabled" {
+			connectionString = fmt.Sprintf("%s&search_path=%s", connectionString, url.QueryEscape(schema))
+		}
 	}
-	db, err := sql.Open("postgres", con)
+
+	db, err := sql.Open("postgres", connectionString)
 	if err != nil {
 		fmt.Printf("Could not connect to database, check your env variables!")
 		return nil, err


### PR DESCRIPTION
Follow up to https://github.com/zoriya/Kyoo/pull/899. This differs from the other PRs in that rather than supporting standard libpq environment variables, a connection string can be specified instead. Setting this variable will ignore all other connection variables.

When/if this service is moved to pgx, the logic from the auth service can be copy/pasted here (or turned into a module and called). My intent with this change was to minimize the amount of work that would need to be thrown away when migrating, while also supporting TLS connections + TLS auth.