### PR TITLE
Add support for RabbitMQ connection string to the Scanner service

### DIFF
--- a/scanner/.env.example
+++ b/scanner/.env.example
@@ -1,0 +1,12 @@
+# vi: ft=sh
+# shellcheck disable=SC2034
+
+# RabbitMQ settings
+# URL examples: https://docs.aio-pika.com/#url-examples
+# This uses AIORMQ (https://github.com/mosquito/aiormq/) under the hood, and supports whatever the library supports.
+# RABBITMQ_URL=ampqs://user:password@rabbitmq-server:1234/vhost?capath=/path/to/cacert.pem&certfile=/path/to/cert.pem&keyfile=/path/to/key.pem
+# These values are ignored when the RABBITMQ_URL is set
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest

--- a/scanner/providers/rabbit_base.py
+++ b/scanner/providers/rabbit_base.py
@@ -7,6 +7,7 @@ class RabbitBase:
 
 	async def __aenter__(self):
 		self._con = await connect_robust(
+			os.environ.get("RABBITMQ_URL"),
 			host=os.environ.get("RABBITMQ_HOST", "rabbitmq"),
 			port=int(os.environ.get("RABBITMQ_PORT", "5672")),
 			login=os.environ.get("RABBITMQ_DEFAULT_USER", "guest"),


### PR DESCRIPTION
Follow-up to https://github.com/zoriya/Kyoo/pull/904 and #905. ~~I'll test these together this weekend to ensure that they work properly.~~