### PR TITLE
[v4] Added support for storing images in S3-compatible object storage

### DIFF
--- a/back/src/Kyoo.Core/Controllers/ThumbnailsManager.cs
+++ b/back/src/Kyoo.Core/Controllers/ThumbnailsManager.cs
@@ -202,9 +202,10 @@ public class ThumbnailsManager(
 	public async Task SetUserImage(Guid userId, Stream? image)
 	{
 		var filePath = $"/metadata/user/{userId}.webp";
-		if (image == null && await storage.DoesExist(filePath))
+		if (image == null)
 		{
-			await storage.Delete(filePath);
+			if (await storage.DoesExist(filePath))
+				await storage.Delete(filePath);
 			return;
 		}
 

--- a/back/src/Kyoo.Core/Kyoo.Core.csproj
+++ b/back/src/Kyoo.Core/Kyoo.Core.csproj
@@ -11,6 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.Proxy" Version="4.5.0" />
+		<PackageReference Include="AWSSDK.S3" Version="3.7.416.15" />
 		<PackageReference Include="Blurhash.SkiaSharp" Version="2.0.0" />
 		<PackageReference Include="Dapper" Version="2.1.44" />
 		<PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
@@ -28,6 +29,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/back/src/Kyoo.Core/Storage/IStorage.cs
+++ b/back/src/Kyoo.Core/Storage/IStorage.cs
@@ -16,28 +16,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
-using Kyoo.Abstractions.Models;
 
-namespace Kyoo.Abstractions.Controllers;
+namespace Kyoo.Core.Storage;
 
-public interface IThumbnailsManager
+/// <summary>
+/// Interface for storage operations.
+/// </summary>
+public interface IStorage
 {
-	Task DownloadImages<T>(T item)
-		where T : IThumbnails;
-
-	Task DownloadImage(Image? image, string what);
-
-	Task<bool> IsImageSaved(Guid imageId, ImageQuality quality);
-
-	Task<Stream> GetImage(Guid imageId, ImageQuality quality);
-
-	Task DeleteImages<T>(T item)
-		where T : IThumbnails;
-
-	Task<Stream> GetUserImage(Guid userId);
-
-	Task SetUserImage(Guid userId, Stream? image);
+	Task<bool> DoesExist(string path);
+	Task<Stream> Read(string path);
+	Task Write(Stream stream, string path);
+	Task Delete(string path);
 }

--- a/back/src/Kyoo.Core/Storage/S3Storage.cs
+++ b/back/src/Kyoo.Core/Storage/S3Storage.cs
@@ -1,0 +1,78 @@
+// Kyoo - A portable and vast media library solution.
+// Copyright (c) Kyoo.
+//
+// See AUTHORS.md and LICENSE file in the project root for full license information.
+//
+// Kyoo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// Kyoo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kyoo. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Microsoft.Extensions.Configuration;
+
+namespace Kyoo.Core.Storage;
+
+/// <summary>
+/// S3-backed storage.
+/// </summary>
+public class S3Storage(IAmazonS3 s3Client, IConfiguration configuration) : IStorage
+{
+	public const string S3BucketEnvironmentVariable = "S3_BUCKET_NAME";
+
+	public Task<bool> DoesExist(string path)
+	{
+		return s3Client
+			.GetObjectMetadataAsync(_GetBucketName(), path)
+			.ContinueWith(t =>
+			{
+				if (t.IsFaulted)
+					return false;
+
+				return t.Result.HttpStatusCode == System.Net.HttpStatusCode.OK;
+			});
+	}
+
+	public async Task<Stream> Read(string path)
+	{
+		var response = await s3Client.GetObjectAsync(_GetBucketName(), path);
+		return response.ResponseStream;
+	}
+
+	public Task Write(Stream reader, string path)
+	{
+		return s3Client.PutObjectAsync(
+			new Amazon.S3.Model.PutObjectRequest
+			{
+				BucketName = _GetBucketName(),
+				Key = path,
+				InputStream = reader
+			}
+		);
+	}
+
+	public Task Delete(string path)
+	{
+		return s3Client.DeleteObjectAsync(_GetBucketName(), path);
+	}
+
+	private string _GetBucketName()
+	{
+		var bucketName = configuration.GetValue<string>(S3BucketEnvironmentVariable);
+		if (string.IsNullOrEmpty(bucketName))
+			throw new InvalidOperationException("S3 bucket name is not configured.");
+
+		return bucketName;
+	}
+}


### PR DESCRIPTION
This is the v4 version of https://github.com/zoriya/Kyoo/pull/896. This PR allows all backend service file storage to store files in S3-compatible object storage.

The benefit of using S3 here is that when multiple replicas of the service are running, they will now all have access to the same set of images. Returned values for /images/:id should now be consistent, regardless of which replica serves a response. In addition, images should only be downloaded and stored once for the entire service, instead of once per replica.

I've abstracted the Thumbnail Manager a little bit to allow it to be backed by a class that performs simple storage CRUD operations. It will continue to default to file storage, and will only use S3 storage if a bucket is configured.

The environment variables that should be used to configure the S3 client are documented here: https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html

I don't have a super easy way to test this, as running the backend service requires setting up postgres + rabbitmq + maybe more locally. I will probably publish a v4 release to my fork with this and the other PRs, and run it in my cluster. Given that another v4 release isn't currently planned, this doesn't really need to be merged. I'm mainly filing this for visibility for anybody else interested in the feature.