### PR TITLE
Update workflows to work on forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,42 +22,44 @@ jobs:
           - context: ./back
             dockerfile: Dockerfile
             label: back
-            image: zoriya/kyoo_back
+            image: ${{ github.repository_owner }}/kyoo_back
 
           - context: ./back
             dockerfile: Dockerfile.migrations
             label: migrations
-            image: zoriya/kyoo_migrations
+            image: ${{ github.repository_owner }}/kyoo_migrations
 
           - context: ./api
             dockerfile: Dockerfile
             label: api
-            image: zoriya/kyoo_api
+            image: ${{ github.repository_owner }}/kyoo_api
 
           - context: ./front
             dockerfile: Dockerfile
             label: front
-            image: zoriya/kyoo_front
+            image: ${{ github.repository_owner }}/kyoo_front
 
           - context: ./scanner
             dockerfile: Dockerfile
             label: scanner
-            image: zoriya/kyoo_scanner
+            image: ${{ github.repository_owner }}/kyoo_scanner
 
           - context: ./autosync
             dockerfile: Dockerfile
             label: autosync
-            image: zoriya/kyoo_autosync
+            image: ${{ github.repository_owner }}/kyoo_autosync
 
           - context: ./transcoder
             dockerfile: Dockerfile
             label: transcoder
-            image: zoriya/kyoo_transcoder
+            image: ${{ github.repository_owner }}/kyoo_transcoder
 
           - context: ./auth
             dockerfile: Dockerfile
             label: auth
-            image: zoriya/keibi
+            image: ${{ github.repository_owner }}/keibi
+    env:
+      DOCKERHUB_ENABLED: ${{ secrets.DOCKER_USERNAME && secrets.DOCKER_PASSWORD && 'true' || 'false' }}
     name: Build ${{matrix.label}}
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +76,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            docker.io/${{matrix.image}}
+            docker.io/${{matrix.image}},enable=${{ env.DOCKERHUB_ENABLED }}
             ghcr.io/${{matrix.image}}
           tags: |
             type=edge
@@ -94,7 +96,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: env.SHOULD_PUSH == 'true'
+        if: env.SHOULD_PUSH == 'true' && env.DOCKERHUB_ENABLED == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -124,7 +126,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Sync README.MD
-        if: env.SHOULD_PUSH == 'true'
+        if: env.SHOULD_PUSH == 'true' && env.DOCKERHUB_ENABLED == 'true'
         uses: ms-jpq/sync-dockerhub-readme@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/helm-release-chart.yml
+++ b/.github/workflows/helm-release-chart.yml
@@ -31,7 +31,12 @@ jobs:
       run: |
         export tag=$(echo ${GITHUB_REF#refs/tags/} | sed 's/^v//')
         helm package ./chart --version $tag --app-version $tag
+    
+    - name: Build Helm-safe repo name
+      run: |
+        REPO_NAME="$(echo "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm-charts" | tr '[:upper:]' '[:lower:]')"
+        echo "REPO_NAME=${REPO_NAME}" >> "${GITHUB_ENV}"
 
     - name: Push Helm Chart to GHCR
       run: |
-        helm push kyoo-*.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts
+        helm push kyoo-*.tgz "${REPO_NAME}"

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -15,15 +15,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check for EXPO_TOKEN
+      # This is required because GHA doesn't support secrets in the `if` condition
+      - name: Check if Expo build is enabled
+        env:
+          IS_SECRET_SET: ${{ env.IS_EXPO_ENABLED == 'true' && 'true' || 'false' }}
+        run: echo "IS_EXPO_ENABLED=${IS_SECRET_SET}" >> "${GITHUB_ENV}"
+
+      - name: Log if Expo build is disabled due to fork
+        if: env.IS_EXPO_ENABLED != 'true'
         run: |
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
-            exit 1
-          fi
+          echo "Expo build is disabled for forks. To enable it, add an EXPO_TOKEN secret to this repository. See https://docs.expo.dev/eas-update/github-actions/ for more information."
 
       - name: Setup Node
         uses: actions/setup-node@v4
+        if: env.IS_EXPO_ENABLED == 'true'
         with:
           node-version: 22.x
           cache: yarn
@@ -31,34 +36,40 @@ jobs:
 
       - name: Setup Expo
         uses: expo/expo-github-action@v8
+        if: env.IS_EXPO_ENABLED == 'true'
         with:
           expo-version: latest
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
+        if: env.IS_EXPO_ENABLED == 'true'
         run: yarn install --immutable
 
       - name: Build Mobile Release
+        if: env.IS_EXPO_ENABLED == 'true'
         run: yarn build:mobile:apk | tee log.txt
 
       - name: Parse Asset URL
         id: url
+        if: env.IS_EXPO_ENABLED == 'true'
         run: |
           ASSET_URL=$(cat log.txt | jq '.[0].artifacts.buildUrl' -r)
           echo The android url is $ASSET_URL
           echo "assetUrl=$ASSET_URL" >> $GITHUB_OUTPUT
 
       - name: Download APK Asset
+        if: env.IS_EXPO_ENABLED == 'true'
         run: wget -O kyoo.apk ${{ steps.url.outputs.assetUrl }}
 
       - uses: actions/upload-artifact@v4
+        if: env.IS_EXPO_ENABLED == 'true'
         with:
           name: kyoo.apk
           path: ./front/kyoo.apk
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: env.IS_EXPO_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/')
         with:
           files: ./front/kyoo.apk

--- a/.github/workflows/native-update.yml
+++ b/.github/workflows/native-update.yml
@@ -15,15 +15,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check for EXPO_TOKEN
+      # This is required because GHA doesn't support secrets in the `if` condition
+      - name: Check if Expo build is enabled
+        env:
+          IS_SECRET_SET: ${{ env.IS_EXPO_ENABLED == 'true' && 'true' || 'false' }}
+        run: echo "IS_EXPO_ENABLED=${IS_SECRET_SET}" >> "${GITHUB_ENV}"
+
+      - name: Log if Expo build is disabled due to fork
+        if: env.IS_EXPO_ENABLED != 'true'
         run: |
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
-            exit 1
-          fi
+          echo "Expo build is disabled for forks. To enable it, add an EXPO_TOKEN secret to this repository. See https://docs.expo.dev/eas-update/github-actions/ for more information."
 
       - name: Setup Node
         uses: actions/setup-node@v4
+        if: env.IS_EXPO_ENABLED == 'true'
         with:
           node-version: 22.x
           cache: yarn
@@ -31,13 +36,16 @@ jobs:
 
       - name: Setup Expo
         uses: expo/expo-github-action@v8
+        if: env.IS_EXPO_ENABLED == 'true'
         with:
           expo-version: latest
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
+        if: env.IS_EXPO_ENABLED == 'true'
         run: yarn install --immutable
 
       - name: Publish update
+        if: env.IS_EXPO_ENABLED == 'true'
         run: yarn update


### PR DESCRIPTION
There are a handful of workflow steps that cannot be ran on forks (at least easily). This selectively enables some workflow logic only if the required secrets are present. It also removes the hard-coded "zoriya" prefix from image names so that images able to be pushed to forked repos when a release is cut.

Here is a release I cut on my fork with these changes: https://github.com/solidDoWant/Kyoo/releases/tag/v4.8.0-dev.4