### PR TITLE
Fix scanner message storm caused by #916

### DIFF
--- a/scanner/scanner/__init__.py
+++ b/scanner/scanner/__init__.py
@@ -6,12 +6,17 @@ async def main():
 	from .scanner import scan
 	from .refresher import refresh
 	from .publisher import Publisher
+	from .subscriber import Subscriber
 	from providers.kyoo_client import KyooClient
 
 	logging.basicConfig(level=logging.INFO)
 	logging.getLogger("watchfiles").setLevel(logging.WARNING)
 
-	async with Publisher() as publisher, KyooClient() as client:
+	async with (
+		Publisher() as publisher,
+		Subscriber() as subscriber,
+		KyooClient() as client,
+	):
 		path = os.environ.get("SCANNER_LIBRARY_ROOT", "/video")
 
 		async def scan_all():
@@ -21,5 +26,5 @@ async def main():
 			monitor(path, publisher, client),
 			scan_all(),
 			refresh(publisher, client),
-			publisher.listen(scan_all),
+			subscriber.listen(scan_all),
 		)

--- a/scanner/scanner/subscriber.py
+++ b/scanner/scanner/subscriber.py
@@ -1,0 +1,24 @@
+import asyncio
+from guessit.jsonutils import json
+from aio_pika.abc import AbstractIncomingMessage
+from logging import getLogger
+
+from providers.rabbit_base import RabbitBase
+
+logger = getLogger(__name__)
+
+
+class Subscriber(RabbitBase):
+	QUEUE = "scanner.rescan"
+
+	async def listen(self, scan):
+		async def on_message(message: AbstractIncomingMessage):
+			try:
+				await scan()
+				await message.ack()
+			except Exception as e:
+				logger.exception("Unhandled error", exc_info=e)
+				await message.reject()
+
+		await self._queue.consume(on_message)
+		await asyncio.Future()


### PR DESCRIPTION
When I added support for passively declared queues in #916, I removed the code that adds a the `scanner.rescan` queue. Due to coupling between the two queues in the publisher class, this resulted in all messages being sent and received over the `scanner` channel.

The listener does not discriminate messages based on action, so nearly every single message sent by the two resulted in a new rescan... which in turn sent more messages. Here's what that looked like:
![Peaks are where the processes got OOM killed](https://github.com/user-attachments/assets/2c25e35c-5805-4a89-aadc-56360bc64f19)
!["0" is actually about 50k-100k](https://github.com/user-attachments/assets/b943d866-7277-43bd-91da-e52e5a39b4d9)

This separates out the subscriber logic into a separate class, with separate queues. Doing so also fixed a bug where a rabbitmq channel would be created but never closed, because the publisher assigned both queues to the same var.

I'm running this in my cluster and it has fixed the issue.