### PR TITLE
Backend: Fix pooling configuration always overriding connection string parameters

### DIFF
--- a/back/src/Kyoo.Postgresql/PostgresModule.cs
+++ b/back/src/Kyoo.Postgresql/PostgresModule.cs
@@ -33,15 +33,19 @@ public static class PostgresModule
 {
 	public static NpgsqlDataSource CreateDataSource(IConfiguration configuration)
 	{
+		var connectionString = configuration.GetValue<string>("POSTGRES_URL");
+
 		// Load the connection string from the environment variable, as well as standard libpq environment variables
 		// (PGUSER, PGPASSWORD, PGHOST, PGPORT, PGDATABASE, etc.)
-		NpgsqlConnectionStringBuilder conBuilder =
-			new(configuration.GetValue<string>("POSTGRES_URL") ?? "")
-			{
-				Pooling = true,
-				MaxPoolSize = 95,
-				Timeout = 30
-			};
+		NpgsqlConnectionStringBuilder conBuilder = new(connectionString ?? "");
+		// Set defaults when no explicit connection string is provided. This cannot be set if the connection string
+		// is provided, or it will override connection string values.
+		if (string.IsNullOrEmpty(connectionString))
+		{
+			conBuilder.Pooling = true;
+			conBuilder.MaxPoolSize = 95;
+			conBuilder.Timeout = 30;
+		}
 
 		string? oldVarUsername = configuration.GetValue<string>("POSTGRES_USER");
 		if (!string.IsNullOrEmpty(oldVarUsername))


### PR DESCRIPTION
Pooling configuration parameters always override connection string parameters. Because of this, it is impossible to specify more or less max connections, and pooled connection timeout. This PR disables these overrides _only_ when a connection string is provided.