### PR TITLE
Add support for QSV with newer Intel iGPUs

### DIFF
--- a/transcoder/Dockerfile
+++ b/transcoder/Dockerfile
@@ -47,7 +47,9 @@ RUN set -x && apt-get update \
 	# hwaccel dependencies
 	vainfo mesa-va-drivers \
 	# intel hwaccel dependencies, not available everywhere
-	$([ " $TARGETARCH" = " amd64" ] && echo "intel-media-va-driver-non-free i965-va-driver-shaders") \
+	# Install QSV packages required by ffmpeg here: https://trac.ffmpeg.org/wiki/Hardware/QuickSync
+	# libvpl2 is required for newer Intel iGPUs, such as those on Raptor Lake
+	$([ " $TARGETARCH" = " amd64" ] && echo "intel-media-va-driver-non-free i965-va-driver-shaders libmfx-gen1.2 libvpl2 libigfxcmrt7") \
 	# CA certificates for HTTPS to S3 buckets
 	ca-certificates \
 	&& apt-get clean autoclean -y \


### PR DESCRIPTION
Newer Intel iGPUs require some additional packages for QSV transcoding. Tested this on an i9-13900H.

This works, but audio with QSV transcoding _specifically_ is about 1s behind. Not sure if this was introduced by these changes, or if there is another issue with QSV transcoding. I'd need somebody else to test on some older hardware to get a better idea of where the problem lies. VAAPI works fine on the same hardware.