### PR TITLE
Transcoder: Fixed background jobs terminating when web request is cancelled

### DIFF
--- a/transcoder/src/metadata.go
+++ b/transcoder/src/metadata.go
@@ -153,10 +153,10 @@ func (s *MetadataService) GetMetadata(ctx context.Context, path string, sha stri
 	}
 
 	if ret.Versions.Thumbs < ThumbsVersion {
-		go s.ExtractThumbs(ctx, path, sha)
+		go s.ThumbnailExtractionJob(ctx, path, sha)
 	}
 	if ret.Versions.Extract < ExtractVersion {
-		go s.ExtractSubs(ctx, ret)
+		go s.SubtitleExtractionJob(ctx, ret)
 	}
 	if ret.Versions.Keyframes < KeyframeVersion && ret.Versions.Keyframes != 0 {
 		for _, video := range ret.Videos {

--- a/transcoder/src/storage/storage.go
+++ b/transcoder/src/storage/storage.go
@@ -72,7 +72,7 @@ func SaveFilesToBackend(ctx context.Context, backend StorageBackend, sourceDirec
 			if err != nil {
 				return fmt.Errorf("failed to open file %q: %w", sourcePath, err)
 			}
-			utils.CleanupWithErr(&err, file.Close, "failed to close file %q", sourcePath)
+			defer utils.CleanupWithErr(&err, file.Close, "failed to close file %q", sourcePath)
 
 			if err := backend.SaveItem(ctx, destinationPath, file); err != nil {
 				return fmt.Errorf("failed to save file %q to backend: %w", sourcePath, err)

--- a/transcoder/src/utils/utils.go
+++ b/transcoder/src/utils/utils.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 )
 
@@ -51,4 +53,48 @@ func CleanupWithErr(err *error, fn func() error, msg string, args ...any) {
 		*err = fmt.Errorf("%s: %w", fmt.Sprintf(msg, args...), cleanupErr)
 	}
 	*err = errors.Join(*err, cleanupErr)
+}
+
+// RunJob runs a job in the background and waits for it to complete.
+// If the job takes longer than maxJobDuration, it will be cancelled via a separate cancellation context.
+// If the waitContext is cancelled, the job will continue running in the background until it completes,
+// or the maxJobDuration is reached.
+// An error is returned if the provided context is cancelled, or the job errors out.
+func RunJob(waitContext context.Context, job func(context.Context) error, maxJobDuration time.Duration) error {
+	defer PrintExecTime("background job with max duration %v", maxJobDuration)()
+
+	// Job completion signal, time limit + cancellation, error capturing
+	jobDone := make(chan struct{})
+	jobClose := sync.OnceFunc(func() { close(jobDone) })
+	defer jobClose()
+
+	// TODO this should be cancelled via a root cancellation context (listen for OS signals, etc.)
+	jobCtx, cancel := context.WithTimeout(context.TODO(), maxJobDuration)
+
+	var jobErr error
+
+	// Start the job
+	go func() {
+		jobErr = job(jobCtx)
+
+		// Log the error if the job fails and the caller has already cancelled the context
+		// This ensures that errors are not completely lost if the outer function has already returned
+		if jobErr != nil && waitContext.Err() != nil {
+			log.Printf("Background job failed: %v", jobErr)
+		}
+
+		// Signal that the job is done
+		jobClose()
+		cancel()
+	}()
+
+	// Wait for the job to complete, or the provided context to be cancelled.
+	// If the context is cancelled, the job will continue running in the background.
+	select {
+	case <-jobDone:
+	case <-waitContext.Done():
+		return fmt.Errorf("context was cancelled while waiting for the job to complete: %w", waitContext.Err())
+	}
+
+	return jobErr
 }


### PR DESCRIPTION
With some of the recent changes to how contexts are passed around, background jobs have been getting cancelled when the web request that spawned them is cancelled. This runs all transcoder background jobs (subtitles, attachments, thumbnails) in a separate goroutine with its own time-limited context.

This also fixes a few one-line bugs that aren't worth a separate PR:
* Saving files from disk fails because the file is closed prior to upload instead of after
* Job/runlock completion can hang indefinitely when any single listener doesn't read the result
