### PR TITLE
Added support for considering DTS audio streams when determing player codec support

### DIFF
--- a/transcoder/src/codec.go
+++ b/transcoder/src/codec.go
@@ -115,6 +115,11 @@ func GetMimeCodec(stream *ffprobe.Stream) *string {
 		ret := "alac"
 		return &ret
 
+	// Based on https://cconcolato.github.io/media-mime-support/#video/mp4;%20codecs=%22dtsc%22
+	case "dts":
+		ret := "dtsc"
+		return &ret
+
 	default:
 		log.Printf("No known mime format for: %s", stream.CodecName)
 		return nil

--- a/transcoder/src/codec.go
+++ b/transcoder/src/codec.go
@@ -115,9 +115,31 @@ func GetMimeCodec(stream *ffprobe.Stream) *string {
 		ret := "alac"
 		return &ret
 
-	// Based on https://cconcolato.github.io/media-mime-support/#video/mp4;%20codecs=%22dtsc%22
+	// MIME type codec values: https://cconcolato.github.io/media-mime-support/#video/mp4;%20codecs=%22dtsc%22
+	// Profiles supported by ffmpeg: https://github.com/FFmpeg/FFmpeg/blob/1b643e3f65d75a4e6a25986466254bdd4fc1a01a/libavcodec/profiles.c#L40-L50
 	case "dts":
-		ret := "dtsc"
+		ret := "dts"
+		switch strings.ToLower(stream.Profile) {
+		case "dts-hd hra": // DTS-HD High Resolution Audio
+			ret += "h"
+		case "dts-hd ma": // DTS-HD Master Audio
+			ret += "l"
+		case "dts-hd ma + dts:x": // DTS-HD Master Audio + DTS:X
+			fallthrough
+		case "dts-hd ma + dts-hd imax": // DTS-HD Master Audio + DTS:X IMAX (?)
+			ret += "x"
+		case "dts express": // DTS Express, AKA DTS LBR
+			ret += "e"
+		case "dts": // Plain DTS. The original codec name was "Digital Coherent Acoustics", which is where the "c" comes from. All other codecs are a superset of "dtsc".
+			fallthrough
+		// Profiles with unknown MIME type codec value(s)
+		case "dts-es": // DTS-ES (Extended Surround)
+			fallthrough
+		case "dts 96/24": // DTS 96/24
+			fallthrough
+		default:
+			ret += "c"
+		}
 		return &ret
 
 	default:

--- a/transcoder/src/info.go
+++ b/transcoder/src/info.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
-const InfoVersion = 1
+const InfoVersion = 2
 
 type Versions struct {
 	Info      int32 `json:"info"`


### PR DESCRIPTION
This adds the DTS codec type to the media MIME type, when a DTS stream is the primary audio stream.

This change will cause media info in the DB to be regenerated.

I'm not 100% sure if this is the correct value for the codec type (see link for values). FFmpeg reports the type as `DTS (dtc)`. Getting this wrong should be minimally impactful, as current clients utilizing this code path _very_ likely do not support any form of DTS audio streams.
