### PR TITLE
Cleanly handle unsupported subtitles

### DIFF
--- a/front/packages/ui/src/player/components/right-buttons.tsx
+++ b/front/packages/ui/src/player/components/right-buttons.tsx
@@ -71,15 +71,17 @@ export const RightButtons = ({
 						selected={!selectedSubtitle}
 						onSelect={() => setSubtitle(null)}
 					/>
-					{subtitles.map((x, i) => (
-						<Menu.Item
-							key={x.index ?? i}
-							label={x.link ? getSubtitleName(x) : `${getSubtitleName(x)} (${x.codec})`}
-							selected={selectedSubtitle === x}
-							disabled={!x.link}
-							onSelect={() => setSubtitle(x)}
-						/>
-					))}
+					{subtitles
+						.filter((x) => !!x.link)
+						.map((x, i) => (
+							<Menu.Item
+								key={x.index ?? i}
+								label={x.link ? getSubtitleName(x) : `${getSubtitleName(x)} (${x.codec})`}
+								selected={selectedSubtitle === x}
+								disabled={!x.link}
+								onSelect={() => setSubtitle(x)}
+							/>
+						))}
 				</Menu>
 			)}
 			<AudiosMenu

--- a/front/packages/ui/src/player/video.tsx
+++ b/front/packages/ui/src/player/video.tsx
@@ -109,12 +109,14 @@ const Video = forwardRef<VideoRef, VideoProps>(function Video(
 				}
 				// when video file is invalid, audio is undefined
 				selectedAudioTrack={{ type: SelectedTrackType.INDEX, value: audio?.index ?? 0 }}
-				textTracks={subtitles?.map((x) => ({
-					type: MimeTypes.get(x.codec) as any,
-					uri: x.link!,
-					title: x.title ?? "Unknown",
-					language: x.language ?? ("Unknown" as any),
-				}))}
+				textTracks={subtitles
+					?.filter((x) => !!x.link)
+					.map((x) => ({
+						type: MimeTypes.get(x.codec) as any,
+						uri: x.link!,
+						title: x.title ?? "Unknown",
+						language: x.language ?? ("Unknown" as any),
+					}))}
 				selectedTextTrack={
 					subtitle
 						? {

--- a/transcoder/src/extract.go
+++ b/transcoder/src/extract.go
@@ -63,8 +63,15 @@ func (s *MetadataService) GetSubtitle(ctx context.Context, sha string, name stri
 func (s *MetadataService) extractSubs(ctx context.Context, info *MediaInfo) (err error) {
 	defer utils.PrintExecTime("extraction of %s", info.Path)()
 
-	// If there is no subtitles, there is nothing to extract (also fonts would be useless).
-	if len(info.Subtitles) == 0 {
+	// If there are no supported, embedded subtitles, there is nothing to extract.
+	hasSupportedSubtitle := false
+	for _, sub := range info.Subtitles {
+		if !sub.IsExternal && sub.Extension != nil {
+			hasSupportedSubtitle = true
+			break
+		}
+	}
+	if !hasSupportedSubtitle {
 		return nil
 	}
 


### PR DESCRIPTION
This handles unsupported (primarily bitmap) embedded subtitles "nicely". On the backend, when only unsupported subtitle formats are embedded, ffmpeg is never called. This keeps the transcoder from logging an unimportant error (noise). On the frontend, these subtitles are now hidden in the player:

![image](https://github.com/user-attachments/assets/6557bd4a-dc0c-49c8-84e8-12ad6566858c)
