### PR TITLE
Reduce playback start time by 100x

### DIFF
--- a/transcoder/src/keyframes.go
+++ b/transcoder/src/keyframes.go
@@ -14,7 +14,11 @@ import (
 	"github.com/zoriya/kyoo/transcoder/src/utils"
 )
 
-const KeyframeVersion = 1
+const (
+	KeyframeVersion        = 1
+	minParsedKeyframeTime  = 5.0 // seconds
+	minParsedKeyframeCount = 3
+)
 
 type Keyframe struct {
 	Keyframes []float64
@@ -22,9 +26,13 @@ type Keyframe struct {
 	info      *KeyframeInfo
 }
 type KeyframeInfo struct {
-	ready     sync.WaitGroup
-	mutex     sync.RWMutex
-	listeners []func(keyframes []float64)
+	ready sync.WaitGroup
+	mutex sync.RWMutex
+	// This channel is closed when enough keyfraames for index generation
+	// have been parsed. A nil value also indicates that the keyframes have
+	// been parsed.
+	indexKeyframesParsed chan struct{}
+	listeners            []func(keyframes []float64)
 }
 
 func (kf *Keyframe) Get(idx int32) float64 {
@@ -121,6 +129,7 @@ func (s *MetadataService) GetKeyframes(info *MediaInfo, isVideo bool, idx uint32
 	info.lock.Lock()
 	if isVideo {
 		info.Videos[idx].Keyframes = kf
+		kf.info.indexKeyframesParsed = make(chan struct{})
 	} else {
 		info.Audios[idx].Keyframes = kf
 	}
@@ -192,6 +201,8 @@ func getVideoKeyframes(path string, video_idx uint32, kf *Keyframe) error {
 	ret := make([]float64, 0, 1000)
 	limit := 100
 	done := 0
+	indexNotificationComplete := false
+
 	// sometimes, videos can start at a timing greater than 0:00. We need to take that into account
 	// and only list keyframes that come after the start of the video (without that, our segments count
 	// mismatch and we can have the same segment twice on the stream).
@@ -230,6 +241,15 @@ func getVideoKeyframes(path string, video_idx uint32, kf *Keyframe) error {
 		// handled as a segment prevents that.
 
 		ret = append(ret, fpts)
+
+		// Notify listeners that enough keyframes for index generation have been parsed
+		if !indexNotificationComplete && fpts >= minParsedKeyframeTime && len(ret) >= minParsedKeyframeCount {
+			kf.add(ret)
+			done += len(ret)
+			ret = ret[:0]
+			indexNotificationComplete = true
+			close(kf.info.indexKeyframesParsed)
+		}
 
 		if len(ret) == limit {
 			kf.add(ret)

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -72,7 +72,12 @@ func NewStream(file *FileStream, keyframes *Keyframe, handle StreamHandle, ret *
 
 	ret.ready.Add(1)
 	go func() {
-		keyframes.info.ready.Wait()
+		if keyframes.info.indexKeyframesParsed == nil {
+			keyframes.info.ready.Wait()
+		} else {
+			// Use a keyframe-time based notifier if supported
+			<-keyframes.info.indexKeyframesParsed
+		}
 
 		length, is_done := keyframes.Length()
 		ret.segments = make([]Segment, length, max(length, 2000))

--- a/transcoder/src/stream.go
+++ b/transcoder/src/stream.go
@@ -72,12 +72,7 @@ func NewStream(file *FileStream, keyframes *Keyframe, handle StreamHandle, ret *
 
 	ret.ready.Add(1)
 	go func() {
-		if keyframes.info.indexKeyframesParsed == nil {
-			keyframes.info.ready.Wait()
-		} else {
-			// Use a keyframe-time based notifier if supported
-			<-keyframes.info.indexKeyframesParsed
-		}
+		keyframes.info.ready.Wait()
 
 		length, is_done := keyframes.Length()
 		ret.segments = make([]Segment, length, max(length, 2000))


### PR DESCRIPTION
Playback start time is dominated by the keyframe lookup process, which needs partial completion before the playback index can be generated and returned to the client. Currently, this requires a minimum of 100 keyframes, regardless of segment duration, to be parsed before this happens. This can take 2s to 2m, depending on segment size, file size, and disk IO load.

Rather than requiring a flat 100 keyframes, this PR changes the index generation logic to require both 5s worth of keyframes and a count of 3 keyframes. In many cases I am seeing a playback start time reduction of 100x or more, cutting this process down to about 100ms in most cases.