### PR TITLE
Added support for disabling password login and registration

### DIFF
--- a/back/.env.example
+++ b/back/.env.example
@@ -4,6 +4,13 @@
 # http route prefix (will listen to $KYOO_PREFIX/movie for example)
 KYOO_PREFIX=""
 
+
+# Optional authentication settings
+# Set to true to disable login with password (OIDC auth must be configured)
+# AUTHENTICATION_DISABLE_PASSWORD_LOGIN=true
+# Set to true to disable the creation of new users (OIDC auth must be configured)
+# AUTHENTICATION_DISABLE_USER_REGISTRATION=true
+
 # Postgres settings
 # POSTGRES_URL=postgres://user:password@hostname:port/dbname?sslmode=verify-full&sslrootcert=/path/to/server.crt&sslcert=/path/to/client.crt&sslkey=/path/to/client.key
 # The behavior of the below variables match what is documented here:

--- a/back/src/Kyoo.Authentication/Attributes/DisableOnEnvVarAttribute.cs
+++ b/back/src/Kyoo.Authentication/Attributes/DisableOnEnvVarAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kyoo.Authentication.Attributes;
+
+/// <summary>
+/// Disables the action if the specified environment variable is set to true.
+/// </summary>
+public class DisableOnEnvVarAttribute(string varName) : Attribute, IResourceFilter
+{
+	public void OnResourceExecuting(ResourceExecutingContext context)
+	{
+		var config = context.HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+
+		if (config.GetValue(varName, false))
+			context.Result = new Microsoft.AspNetCore.Mvc.NotFoundResult();
+	}
+
+	public void OnResourceExecuted(ResourceExecutedContext context) { }
+}

--- a/back/src/Kyoo.Authentication/Models/DTO/ServerInfo.cs
+++ b/back/src/Kyoo.Authentication/Models/DTO/ServerInfo.cs
@@ -51,6 +51,16 @@ public class ServerInfo
 	/// Check if kyoo's setup is finished.
 	/// </summary>
 	public SetupStep SetupStatus { get; set; }
+
+	/// <summary>
+	/// True if password login is enabled on this instance.
+	/// </summary>
+	public bool PasswordLoginEnabled { get; set; }
+
+	/// <summary>
+	/// True if registration is enabled on this instance.
+	/// </summary>
+	public bool RegistrationEnabled { get; set; }
 }
 
 public class OidcInfo

--- a/back/src/Kyoo.Authentication/Views/AuthApi.cs
+++ b/back/src/Kyoo.Authentication/Views/AuthApi.cs
@@ -26,6 +26,7 @@ using Kyoo.Abstractions.Models.Attributes;
 using Kyoo.Abstractions.Models.Exceptions;
 using Kyoo.Abstractions.Models.Permissions;
 using Kyoo.Abstractions.Models.Utils;
+using Kyoo.Authentication.Attributes;
 using Kyoo.Authentication.Models;
 using Kyoo.Authentication.Models.DTO;
 using Kyoo.Models;
@@ -206,6 +207,7 @@ public class AuthApi(
 	[HttpPost("login")]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(RequestError))]
+	[DisableOnEnvVar("AUTHENTICATION_DISABLE_PASSWORD_LOGIN")]
 	public async Task<ActionResult<JwtToken>> Login([FromBody] LoginRequest request)
 	{
 		User? user = await users.GetOrDefault(
@@ -241,6 +243,7 @@ public class AuthApi(
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(RequestError))]
 	[ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(RequestError))]
+	[DisableOnEnvVar("AUTHENTICATION_DISABLE_USER_REGISTRATION")]
 	public async Task<ActionResult<JwtToken>> Register([FromBody] RegisterRequest request)
 	{
 		try

--- a/back/src/Kyoo.Core/Views/InfoApi.cs
+++ b/back/src/Kyoo.Core/Views/InfoApi.cs
@@ -23,6 +23,7 @@ using Kyoo.Abstractions.Models.Attributes;
 using Kyoo.Authentication.Models;
 using Kyoo.Core.Controllers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using static Kyoo.Abstractions.Models.Utils.Constants;
 
 namespace Kyoo.Authentication.Views;
@@ -33,7 +34,8 @@ namespace Kyoo.Authentication.Views;
 [ApiController]
 [Route("info")]
 [ApiDefinition("Info", Group = UsersGroup)]
-public class InfoApi(PermissionOption options, MiscRepository info) : ControllerBase
+public class InfoApi(PermissionOption options, MiscRepository info, IConfiguration configuration)
+	: ControllerBase
 {
 	public async Task<ActionResult<ServerInfo>> GetInfo()
 	{
@@ -51,6 +53,14 @@ public class InfoApi(PermissionOption options, MiscRepository info) : Controller
 					))
 					.ToDictionary(x => x.Key, x => x.Value),
 				SetupStatus = await info.GetSetupStep(),
+				PasswordLoginEnabled = !configuration.GetValue(
+					"AUTHENTICATION_DISABLE_PASSWORD_LOGIN",
+					false
+				),
+				RegistrationEnabled = !configuration.GetValue(
+					"AUTHENTICATION_DISABLE_USER_REGISTRATION",
+					false
+				),
 			}
 		);
 	}

--- a/front/packages/models/src/resources/server-info.ts
+++ b/front/packages/models/src/resources/server-info.ts
@@ -61,6 +61,14 @@ export const ServerInfoP = z
 		 * Check if kyoo's setup is finished.
 		 */
 		setupStatus: z.nativeEnum(SetupStep),
+		/*
+		 * True if password login is enabled on this instance.
+		 */
+		passwordLoginEnabled: z.boolean(),
+		/*
+		 * True if registration is enabled on this instance.
+		 */
+		registrationEnabled: z.boolean(),
 	})
 	.transform((x) => {
 		const baseUrl = Platform.OS === "web" ? x.publicUrl : "kyoo://";

--- a/front/packages/ui/src/login/login.tsx
+++ b/front/packages/ui/src/login/login.tsx
@@ -59,7 +59,7 @@ export const LoginPage: QueryPage<{ apiUrl?: string; error?: string }> = ({
 			<H1>{t("login.login")}</H1>
 			<OidcLogin apiUrl={apiUrl} hideOr={!data?.passwordLoginEnabled} />
 			{data?.passwordLoginEnabled && (
-				<Array>
+				<>
 					<P {...css({ paddingLeft: ts(1) })}>{t("login.username")}</P>
 					<Input
 						autoComplete="username"
@@ -96,7 +96,7 @@ export const LoginPage: QueryPage<{ apiUrl?: string; error?: string }> = ({
 							mY: ts(3),
 						})}
 					/>
-				</Array>
+				</>
 			)}
 			<P>
 				<Trans i18nKey="login.or-register">

--- a/front/packages/ui/src/login/oidc.tsx
+++ b/front/packages/ui/src/login/oidc.tsx
@@ -34,7 +34,7 @@ import { useRouter } from "solito/router";
 import { percent, rem, useYoshiki } from "yoshiki/native";
 import { ErrorView } from "../errors";
 
-export const OidcLogin = ({ apiUrl }: { apiUrl?: string }) => {
+export const OidcLogin = ({ apiUrl, hideOr }: { apiUrl?: string; hideOr?: boolean }) => {
 	const { css } = useYoshiki();
 	const { t } = useTranslation();
 	const { data, error } = useFetch({ options: { apiUrl }, ...OidcLogin.query() });
@@ -76,6 +76,7 @@ export const OidcLogin = ({ apiUrl }: { apiUrl?: string }) => {
 					flexDirection: "row",
 					width: percent(100),
 					alignItems: "center",
+					display: hideOr ? "none" : undefined,
 				})}
 			>
 				<HR {...css({ flexGrow: 1 })} />

--- a/front/packages/ui/src/login/register.tsx
+++ b/front/packages/ui/src/login/register.tsx
@@ -58,7 +58,7 @@ export const RegisterPage: QueryPage<{ apiUrl?: string }> = ({ apiUrl }) => {
 			<H1>{t("login.register")}</H1>
 			<OidcLogin apiUrl={apiUrl} hideOr={!data?.passwordLoginEnabled} />
 			{data?.registrationEnabled && (
-				<Array>
+				<>
 					<P {...css({ paddingLeft: ts(1) })}>{t("login.username")}</P>
 					<Input
 						autoComplete="username"
@@ -106,7 +106,7 @@ export const RegisterPage: QueryPage<{ apiUrl?: string }> = ({ apiUrl }) => {
 							mY: ts(3),
 						})}
 					/>
-				</Array>
+				</>
 			)}
 			<P>
 				<Trans i18nKey="login.or-login">


### PR DESCRIPTION
This adds support for disabling login via username/password, as well as registration. Enabling these for new installs requires that OIDC auth is configured.

Here's what the login page looks like with password auth disabled:

![image](https://github.com/user-attachments/assets/f16a464c-34d4-42b3-a66a-250b2f7f0a07)


Here's what the registration page looks like with registration disabled:

![image](https://github.com/user-attachments/assets/7ba7101e-d7e1-45f5-8b6e-5ca809d75a19)

Fixes https://github.com/zoriya/Kyoo/issues/566