### PR TITLE
Add Traefik Port Hints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
+      - "traefik.http.services.back.loadbalancer.server.port=5000"
 
   migrations:
     image: ghcr.io/zoriya/kyoo_migrations:edge
@@ -53,6 +54,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.front.rule=PathPrefix(`/`)"
+      - "traefik.http.services.front.loadbalancer.server.port=8901"
 
   scanner:
     image: ghcr.io/zoriya/kyoo_scanner:edge


### PR DESCRIPTION
Couldn't get Traefik to show anything other than 404 Not Found until I told Traefik where front's port was. Added back as well but I am pretty sure thats extra

Reference used to learn Traefik today : https://gist.github.com/fatihyildizhan/8f124039a9bd3801f0caf3c01c3601fb
