### PR TITLE
Fix external subtitles server

### DIFF
--- a/transcoder/src/extract.go
+++ b/transcoder/src/extract.go
@@ -61,9 +61,12 @@ func (s *MetadataService) GetSubtitle(
 	name string,
 ) (io.ReadCloser, error) {
 	// name is either `{index}.{extension}` or `ext-{filename}.{extension}`
-	if strings.HasPrefix(name, "ext") {
-		// external subtitle already available on the fs
-		return os.Open(path)
+	if filename, ok := strings.CutPrefix(name, "ext-"); ok {
+		subPath := filepath.Join(filepath.Dir(path), filename)
+		if !isSubtitleFile(subPath) {
+			return nil, fmt.Errorf("not a subtitle file: %q", filename)
+		}
+		return os.Open(subPath)
 	}
 
 	_, err := s.extractLock.WaitFor(sha)

--- a/transcoder/src/subtitles.go
+++ b/transcoder/src/subtitles.go
@@ -17,6 +17,17 @@ import (
 
 var separator = regexp.MustCompile(`[\s.]+`)
 
+// isSubtitleFile reports whether the path has a known subtitle extension.
+func isSubtitleFile(path string) bool {
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+	for _, subExt := range SubtitleExtensions {
+		if ext == subExt {
+			return true
+		}
+	}
+	return false
+}
+
 func (mi *MediaInfo) SearchExternalSubtitles() error {
 	base_path := strings.TrimSuffix(mi.Path, filepath.Ext(mi.Path))
 	dir, err := os.ReadDir(filepath.Dir(mi.Path))
@@ -35,7 +46,7 @@ outer:
 			if strings.HasSuffix(match, ext) {
 				link := fmt.Sprintf(
 					"/video/%s/subtitle/ext-%s",
-					base64.RawURLEncoding.EncodeToString([]byte(match)),
+					base64.RawURLEncoding.EncodeToString([]byte(mi.Path)),
 					filepath.Base(match),
 				)
 				sub := Subtitle{


### PR DESCRIPTION
Turns out external subtitles were using the DirectStream api to serve files instead of the GetSubtitle. This means external subtitles broke due to #1577. This PR fixes this by using the appropriate GetSubtitle route and also allows external subtitles to have subtitles format conversions (already supported for embedded ones) 