### PR TITLE
Fix home crash for small libraries

### DIFF
--- a/front/src/ui/home/recommended.tsx
+++ b/front/src/ui/home/recommended.tsx
@@ -23,6 +23,7 @@ export const Recommended = () => {
 						{[...Array(itemCount / numColumns)].map((_, y) => {
 							if (!items) return <ItemDetails.Loader key={y} />;
 							const item = items[x * (itemCount / numColumns) + y];
+							if (!item) return null;
 							return (
 								<ItemDetails
 									key={y}


### PR DESCRIPTION
## Summary

- Skip recommendation slots that do not have a corresponding show.

## Why

The home page always renders six recommendation slots. When a library contains fewer than six shows, `items[index]` is `undefined` and accessing `item.slug` throws:

```text
Cannot read properties of undefined (reading 'slug')
```

This prevents small libraries from opening the home page even though the browse page and API are working.

## Impact

Libraries with fewer than six shows can render the home page. Behavior is unchanged when all recommendation slots are populated.

## Validation

- Reproduced the crash with a two-show library.
- Verified the patched home page renders both shows without the error.
- Built the latest `master` frontend Docker image successfully (`bun web`).
- Ran `git diff --check`.
