### PR TITLE
Transcoder: Fix parsing of keyframes for audio

### DIFF
--- a/transcoder/src/keyframes.go
+++ b/transcoder/src/keyframes.go
@@ -341,7 +341,7 @@ func getAudioKeyframes(ctx context.Context, info *MediaInfo, audio_idx uint32, k
 	notified := false
 
 	for scanner.Scan() {
-		pts := scanner.Text()
+		pts := strings.TrimSuffix(scanner.Text(), ",")
 		if pts == "" || pts == "N/A" {
 			continue
 		}


### PR DESCRIPTION
The first line output by ffprobe us suffixed with a coma (just like for videos). However, this coma gets in the way of processing the keyframe's timestamp.

This PR remove the trailing coma, fixing transcoding of audio files