### PR TITLE
Fix chromecast with ac3 audio

### DIFF
--- a/chromecast/bun.lock
+++ b/chromecast/bun.lock
@@ -6,6 +6,7 @@
       "name": "kyoo-chromecast-receiver",
       "dependencies": {
         "blurhash": "^2.0.5",
+        "hls-parser": "^0.16.1",
         "jassub": "1.8.8",
         "libpgs": "^0.8.1",
       },
@@ -113,6 +114,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "hls-parser": ["hls-parser@0.16.1", "", {}, "sha512-6B2XobrddgXNl1pXw0dKXq0ovczjzra/pam7ifV0G/RXpt4bEbQcE6ndY+kGGlrNxB3zE42s7xmIypwG+sxh9A=="],
 
     "jassub": ["jassub@1.8.8", "", { "dependencies": { "rvfc-polyfill": "^1.0.7" } }, "sha512-Vtw27Z0/hN2Tm2Qs4HAR+eONwwSD5ULo/hisPvmiaW9Ya6aFCt7esvWQSZy6nvBASbRyKmpghgeioIPqXGHA0Q=="],
 

--- a/chromecast/package.json
+++ b/chromecast/package.json
@@ -12,6 +12,7 @@
 	},
 	"dependencies": {
 		"blurhash": "^2.0.5",
+		"hls-parser": "^0.16.1",
 		"jassub": "1.8.8",
 		"libpgs": "^0.8.1"
 	},

--- a/chromecast/src/receiver.ts
+++ b/chromecast/src/receiver.ts
@@ -1,3 +1,4 @@
+import { parse, stringify } from "hls-parser";
 import { fetchVideoInfo, fetchVideoMeta, withPresign } from "./api";
 import { asObject, type KyooCastData } from "./cast";
 import { ProgressObserver } from "./progress-observer";
@@ -11,6 +12,33 @@ const {
 	HlsVideoSegmentFormat,
 	GenericMediaMetadata,
 } = cast.framework.messages;
+
+export const filterMasterPlaylist = (
+	text: string,
+	baseUrl: string,
+): string | null => {
+	console.log("parsing manifest:", text);
+	const playlist = parse(text);
+	if (!playlist.isMasterPlaylist) return null;
+
+	const kept = playlist.variants.filter(
+		(v) =>
+			!v.codecs ||
+			MediaSource.isTypeSupported(`video/mp4; codecs="${v.codecs}"`) ||
+			MediaSource.isTypeSupported(`audio/mp4; codecs="${v.codecs}"`),
+	);
+	if (kept.length === 0 || kept.length === playlist.variants.length)
+		return null;
+	playlist.variants = kept;
+
+	// data: URLs have no base to resolve against, so absolutize every URI.
+	for (const v of playlist.variants) {
+		v.uri = new URL(v.uri, baseUrl).href;
+		for (const r of [...v.audio, ...v.video, ...v.subtitles])
+			if (r.uri) r.uri = new URL(r.uri, baseUrl).href;
+	}
+	return stringify(playlist);
+};
 
 export class KyooReceiver {
 	#context = cast.framework.CastReceiverContext.getInstance();
@@ -33,11 +61,13 @@ export class KyooReceiver {
 			this.#subtitles.applyActive(req.activeTrackIds);
 			return req;
 		});
-		this.#player.addEventListener(EventType.MEDIA_FINISHED, () => {
+		this.#player.addEventListener(EventType.MEDIA_FINISHED, (e) => {
 			this.#subtitles.clear();
+			if (e.endedReason === "ERROR") this.#player.stop();
 		});
 		this.#player.addEventListener(EventType.ERROR, (e) => {
 			console.error("[kyoo-receiver] playback error", e);
+			this.#player.stop();
 		});
 
 		const options = new cast.framework.CastReceiverOptions();
@@ -68,17 +98,24 @@ export class KyooReceiver {
 			request.media.hlsVideoSegmentFormat = HlsVideoSegmentFormat.FMP4;
 		}
 
-		// Shaka resolves manifest-relative URLs against the pre-redirect URL (#2679);
-		// kyoo's master 302-redirects, so follow it and hand Shaka the final URL.
+		// Fetch the master ourselves to:
+		// - resolve the 302 (relative urls resolve against the pre-redirect url)
+		//   (https://github.com/shaka-project/shaka-player/issues/2679)
+		// - drop variants the device can't decode
+		//   (https://github.com/shaka-project/shaka-player/issues/9211)
 		if (request.media?.contentUrl) {
 			try {
 				const res = await fetch(request.media.contentUrl, {
 					redirect: "follow",
 				});
-				res.body?.cancel();
-				if (res.redirected && res.url) request.media.contentUrl = res.url;
+				const finalUrl =
+					res.redirected && res.url ? res.url : request.media.contentUrl;
+				const filtered = filterMasterPlaylist(await res.text(), finalUrl);
+				request.media.contentUrl = filtered
+					? `data:application/vnd.apple.mpegurl,${encodeURIComponent(filtered)}`
+					: finalUrl;
 			} catch (e) {
-				console.error("[kyoo-receiver] manifest redirect resolve failed", e);
+				console.error("[kyoo-receiver] manifest fetch/filter failed", e);
 			}
 		}
 

--- a/chromecast/src/ui.ts
+++ b/chromecast/src/ui.ts
@@ -181,7 +181,7 @@ export class ReceiverUi {
 			this.setLoading(false);
 			this.clearError();
 			this.#syncProgress(player);
-			this.show();
+			this.show({ sticky: true });
 		});
 		player.addEventListener(EventType.TIME_UPDATE, () =>
 			this.#syncProgress(player),


### PR DESCRIPTION
Turns out chromecast don't respect the hls spec and fails to play files if one of the track is unsupported. To fix this, we filter out unsupported tracks manually from the master.m3u8 before feeding it to the caf url.