### PR TITLE
Remove multi-codec variants on chromecast

### DIFF
--- a/chromecast/index.html
+++ b/chromecast/index.html
@@ -30,6 +30,10 @@
 				<div class="spinner" role="progressbar" aria-label="Loading"></div>
 			</div>
 
+			<div id="paused" class="paused" hidden>
+				<div class="pause-icon"><span></span><span></span></div>
+			</div>
+
 			<div id="error" class="error" hidden>
 				<img class="error-logo" src="/icon.svg" alt="Kyoo" />
 				<div id="error-title" class="error-title">Playback error</div>

--- a/chromecast/src/api.ts
+++ b/chromecast/src/api.ts
@@ -1,8 +1,7 @@
 export type VideoInfo = {
 	subtitles: {
-		id: string;
 		link: string;
-		mimeType?: string;
+		mimeType: string;
 		label?: string;
 		language?: string;
 	}[];
@@ -49,14 +48,19 @@ export const fetchVideoInfo = async (
 
 	return {
 		subtitles: (data.subtitles ?? [])
-			.map((s, i) => ({
-				id: String(s.index ?? i),
-				link: s.link ? withPresign(new URL(s.link, apiUrl).href, presign) : "",
-				mimeType: s.codec,
-				label: s.title ?? undefined,
-				language: s.language ?? undefined,
-			}))
-			.filter((s) => !!s.link),
+			.filter((s) => !!s.link)
+			.map((s) => {
+				const custom =
+					s.codec === "ass" || s.codec === "ssa" || s.codec.includes("pgs");
+				const link = new URL(s.link!, apiUrl);
+				if (!custom) link.searchParams.set("format", "vtt");
+				return {
+					link: withPresign(link.href, presign),
+					mimeType: custom ? s.codec : "text/vtt",
+					label: s.title ?? undefined,
+					language: s.language ?? undefined,
+				};
+			}),
 		fonts: (data.fonts ?? []).map((f) =>
 			withPresign(new URL(f, apiUrl).href, presign),
 		),

--- a/chromecast/src/receiver.ts
+++ b/chromecast/src/receiver.ts
@@ -11,6 +11,9 @@ const {
 	HlsSegmentFormat,
 	HlsVideoSegmentFormat,
 	GenericMediaMetadata,
+	Track,
+	TrackType,
+	TextTrackType,
 } = cast.framework.messages;
 
 export const filterMasterPlaylist = (
@@ -98,8 +101,6 @@ export class KyooReceiver {
 	): Promise<messages.LoadRequestData> => {
 		const data = (asObject(request.media?.customData) as KyooCastData) ?? {};
 
-		this.#subtitles.registerTracks(request.media?.tracks);
-
 		this.#ui.clearError();
 		this.#ui.dismissSplash();
 		this.#ui.setLoading(true);
@@ -140,10 +141,24 @@ export class KyooReceiver {
 			try {
 				const info = await fetchVideoInfo(data.apiUrl, data.slug, data.presign);
 				this.#subtitles.setFonts(info.fonts);
+				if (request.media) {
+					request.media.tracks = info.subtitles.map((sub, i) => {
+						// caf tracks are 1 based instead of 0 based
+						const track = new Track(i + 1, TrackType.TEXT);
+						track.trackContentId = sub.link;
+						track.trackContentType = sub.mimeType;
+						track.subtype = TextTrackType.SUBTITLES;
+						track.name = sub.label;
+						track.language = sub.language;
+						return track;
+					});
+				}
 			} catch (e) {
-				console.error("[kyoo-receiver] failed to load subtitle fonts", e);
+				console.error("[kyoo-receiver] failed to load subtitles", e);
 			}
 		}
+
+		this.#subtitles.registerTracks(request.media?.tracks);
 		this.#subtitles.applyActive(request.activeTrackIds);
 
 		if (data.apiUrl && data.slug) {

--- a/chromecast/src/receiver.ts
+++ b/chromecast/src/receiver.ts
@@ -103,6 +103,7 @@ export class KyooReceiver {
 
 		this.#ui.clearError();
 		this.#ui.dismissSplash();
+		this.#ui.clearMetadata();
 		this.#ui.setLoading(true);
 		this.#ui.show({ sticky: true });
 

--- a/chromecast/src/receiver.ts
+++ b/chromecast/src/receiver.ts
@@ -104,6 +104,7 @@ export class KyooReceiver {
 		this.#ui.clearError();
 		this.#ui.dismissSplash();
 		this.#ui.clearMetadata();
+		this.#ui.setPaused(false);
 		this.#ui.setLoading(true);
 		this.#ui.show({ sticky: true });
 

--- a/chromecast/src/receiver.ts
+++ b/chromecast/src/receiver.ts
@@ -21,14 +21,29 @@ export const filterMasterPlaylist = (
 	const playlist = parse(text);
 	if (!playlist.isMasterPlaylist) return null;
 
-	const kept = playlist.variants.filter(
+	const supported = playlist.variants.filter(
 		(v) =>
 			!v.codecs ||
 			MediaSource.isTypeSupported(`video/mp4; codecs="${v.codecs}"`) ||
 			MediaSource.isTypeSupported(`audio/mp4; codecs="${v.codecs}"`),
 	);
-	if (kept.length === 0 || kept.length === playlist.variants.length)
-		return null;
+
+	if (supported.length === 0) return null;
+
+	// the device can't switch video codec mid-stream, so keep a single ladder:
+	// the codec with the most variants (ties keep the first, ie the original).
+	const ladders = new Map<string, typeof supported>();
+	for (const v of supported) {
+		const codec = (v.codecs ?? "").split(",")[0].split(".")[0];
+		const ladder = ladders.get(codec);
+		if (ladder) ladder.push(v);
+		else ladders.set(codec, [v]);
+	}
+	const kept = [...ladders.values()].reduce((a, b) =>
+		b.length > a.length ? b : a,
+	);
+
+	if (kept.length === playlist.variants.length) return null;
 	playlist.variants = kept;
 
 	// data: URLs have no base to resolve against, so absolutize every URI.
@@ -37,7 +52,9 @@ export const filterMasterPlaylist = (
 		for (const r of [...v.audio, ...v.video, ...v.subtitles])
 			if (r.uri) r.uri = new URL(r.uri, baseUrl).href;
 	}
-	return stringify(playlist);
+	const ret = stringify(playlist);
+	console.log("stripped manifest:", ret);
+	return ret;
 };
 
 export class KyooReceiver {

--- a/chromecast/src/receiver.ts
+++ b/chromecast/src/receiver.ts
@@ -77,6 +77,10 @@ export class KyooReceiver {
 
 		this.#playbackConfig.initialBandwidth = 20_000_000;
 		this.#player.setMessageInterceptor(MessageType.LOAD, this.#onLoad);
+		this.#player.setMessageInterceptor(
+			MessageType.MEDIA_STATUS,
+			this.#onStatus,
+		);
 		this.#player.setMessageInterceptor(MessageType.EDIT_TRACKS_INFO, (req) => {
 			this.#subtitles.applyActive(req.activeTrackIds);
 			return req;
@@ -95,6 +99,38 @@ export class KyooReceiver {
 		options.maxInactivity = 3600;
 		this.#context.start(options);
 	}
+
+	// cast messages are capped at 64kb. strip all unnecessary data (and presigns)
+	#onStatus = (status: messages.MediaStatus): messages.MediaStatus => {
+		if (!status.media) return status;
+		const copy = <T extends object>(obj: T): T =>
+			Object.assign(Object.create(Object.getPrototypeOf(obj)), obj);
+		const strip = (media: messages.MediaInformation) => {
+			const data = asObject(media.customData) as KyooCastData | null;
+			const stripped = copy(media);
+			stripped.contentUrl =
+				data?.apiUrl && data?.slug
+					? `${data.apiUrl}/api/videos/${data.slug}/master.m3u8`
+					: undefined;
+			stripped.customData = undefined;
+			stripped.tracks = media.tracks?.map((track) => {
+				const copied = copy(track);
+				copied.trackContentId = undefined;
+				return copied;
+			});
+			return stripped;
+		};
+
+		const stripped = copy(status);
+		stripped.media = strip(status.media);
+		stripped.items = status.items?.map((item) => {
+			if (!item.media) return item;
+			const copied = copy(item);
+			copied.media = strip(item.media);
+			return copied;
+		});
+		return stripped;
+	};
 
 	#onLoad = async (
 		request: messages.LoadRequestData,

--- a/chromecast/src/theme.css
+++ b/chromecast/src/theme.css
@@ -118,6 +118,32 @@ cast-media-player {
 	}
 }
 
+.paused {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(15, 23, 42, 0.3);
+}
+.paused[hidden] {
+	display: none;
+}
+.pause-icon {
+	display: flex;
+	gap: 1.25rem;
+	filter: drop-shadow(0 4px 16px rgba(0, 0, 0, 0.6));
+}
+.pause-icon span {
+	width: 26px;
+	height: 84px;
+	border-radius: 6px;
+	background: var(--slate-200);
+}
+
 .error {
 	position: absolute;
 	top: 0;

--- a/chromecast/src/ui.ts
+++ b/chromecast/src/ui.ts
@@ -2,6 +2,7 @@ import { decode } from "blurhash";
 import { castMediaPlayerShadow, getVideoElement } from "./cast";
 
 const { EventType, DetailedErrorCode } = cast.framework.events;
+const { PlayerState } = cast.framework.messages;
 
 const byId = <T extends HTMLElement = HTMLElement>(id: string): T =>
 	document.getElementById(id) as T;
@@ -113,6 +114,7 @@ export class ReceiverUi {
 		splash: byId("splash"),
 		topTitle: byId("top-title"),
 		loading: byId("loading"),
+		paused: byId("paused"),
 		poster: byId<HTMLImageElement>("poster"),
 		title: byId("title"),
 		timeCurrent: byId("time-current"),
@@ -177,6 +179,10 @@ export class ReceiverUi {
 		this.#el.loading.style.display = isLoading ? "flex" : "none";
 	}
 
+	setPaused(isPaused: boolean): void {
+		this.#el.paused.hidden = !isPaused;
+	}
+
 	showError(message: string, detail = "", title = "Playback error"): void {
 		this.setLoading(false);
 		this.#el.errorTitle.textContent = title;
@@ -194,6 +200,7 @@ export class ReceiverUi {
 		player.addEventListener(EventType.PLAYER_LOAD_COMPLETE, () => {
 			this.#pendingLoad = false;
 			this.setLoading(false);
+			this.setPaused(false);
 			this.clearError();
 			this.#syncProgress(player);
 			this.show({ sticky: true });
@@ -206,10 +213,14 @@ export class ReceiverUi {
 		});
 		player.addEventListener(EventType.PLAYING, () => {
 			this.setLoading(false);
+			this.setPaused(false);
 			this.clearError();
 			this.show();
 		});
 		player.addEventListener(EventType.PAUSE, () => {
+			this.setPaused(
+				!this.#pendingLoad && player.getPlayerState() === PlayerState.PAUSED,
+			);
 			this.show({ sticky: true });
 		});
 		player.addEventListener(EventType.ERROR, (e) => {

--- a/chromecast/src/ui.ts
+++ b/chromecast/src/ui.ts
@@ -125,6 +125,7 @@ export class ReceiverUi {
 		errorDetail: byId("error-detail"),
 	};
 	#hideTimer: ReturnType<typeof setTimeout> | null = null;
+	#pendingLoad = false;
 
 	dismissSplash(): void {
 		this.#el.splash.classList.add("gone");
@@ -159,6 +160,19 @@ export class ReceiverUi {
 		}
 	}
 
+	clearMetadata(): void {
+		this.#pendingLoad = true;
+		this.#el.topTitle.textContent = "";
+		this.#el.title.textContent = "";
+		this.#el.poster.hidden = true;
+		this.#el.poster.removeAttribute("src");
+		this.#el.poster.style.backgroundImage = "";
+		this.#el.progressFill.style.width = "0%";
+		this.#el.progressBuffer.style.width = "0%";
+		this.#el.timeCurrent.textContent = "00:00";
+		this.#el.timeTotal.textContent = "??:??";
+	}
+
 	setLoading(isLoading: boolean): void {
 		this.#el.loading.style.display = isLoading ? "flex" : "none";
 	}
@@ -178,6 +192,7 @@ export class ReceiverUi {
 
 	bindTo(player: framework.PlayerManager): void {
 		player.addEventListener(EventType.PLAYER_LOAD_COMPLETE, () => {
+			this.#pendingLoad = false;
 			this.setLoading(false);
 			this.clearError();
 			this.#syncProgress(player);
@@ -203,6 +218,7 @@ export class ReceiverUi {
 	}
 
 	#syncProgress(player: framework.PlayerManager): void {
+		if (this.#pendingLoad) return;
 		const video = getVideoElement();
 		let buffered = Number.NaN;
 		try {

--- a/front/bun.lock
+++ b/front/bun.lock
@@ -46,7 +46,7 @@
         "react-native-localization-settings": "^1.2.0",
         "react-native-mmkv": "^4.3.1",
         "react-native-nitro-modules": "^0.35.7",
-        "react-native-omni": "^1.11.1",
+        "react-native-omni": "^1.11.2",
         "react-native-pager-view": "8.0.2",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
@@ -1279,7 +1279,7 @@
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.10", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-KsySOAIkbSTjNiX2GvXiNT9P5DMeZd99yvtE/+Lw7RXV7Ztxh9Z+YyAbYkBqadhN5J/KXXuPjhRYgyLOIZgsbQ=="],
 
-    "react-native-omni": ["react-native-omni@1.11.1", "", { "dependencies": { "@expo/config-plugins": "^57.0.3", "@videojs/core": "github:zoriya/v10#build26-core", "@videojs/media": "github:zoriya/v10#build26-media", "@videojs/react": "github:zoriya/v10#build26-react", "@videojs/spf": "github:zoriya/v10#build26-spf", "@videojs/store": "github:zoriya/v10#build26-store", "@videojs/utils": "github:zoriya/v10#build26-utils", "jassub": "^2.5.7", "libpgs": "^0.8.1" }, "peerDependencies": { "react": ">=19.0.0", "react-native": ">=0.86.0", "react-native-nitro-modules": ">=0.36.0" } }, "sha512-5HITGj11Yp3bq/ML2PWwzCdxw9HftPyM3wCjEvJsiN0H5jVy3yOua/qzZCFiMnhaZQxguMbr1CXCW+sKjiCQKg=="],
+    "react-native-omni": ["react-native-omni@1.11.2", "", { "dependencies": { "@expo/config-plugins": "^57.0.3", "@videojs/core": "github:zoriya/v10#build26-core", "@videojs/media": "github:zoriya/v10#build26-media", "@videojs/react": "github:zoriya/v10#build26-react", "@videojs/spf": "github:zoriya/v10#build26-spf", "@videojs/store": "github:zoriya/v10#build26-store", "@videojs/utils": "github:zoriya/v10#build26-utils", "jassub": "^2.5.7", "libpgs": "^0.8.1" }, "peerDependencies": { "react": ">=19.0.0", "react-native": ">=0.86.0", "react-native-nitro-modules": ">=0.36.0" } }, "sha512-bHLFxDdeLgOfnIZeyW9MvlFxorF7alWescyI4mAG88Ci3Kyaf1xRoQgM0QRcbdpVncL9b0pPS8sUn95cCep6ww=="],
 
     "react-native-pager-view": ["react-native-pager-view@8.0.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Y8All2BbjidI4ZIF9kBOIIoldkqrY/2FXapHZMdjwD+ByXhiOWTFenPs5rq9KRN5uAH/gOXtQCqHLxQDNBQRiQ=="],
 

--- a/front/package.json
+++ b/front/package.json
@@ -58,7 +58,7 @@
 		"react-native-localization-settings": "^1.2.0",
 		"react-native-mmkv": "^4.3.1",
 		"react-native-nitro-modules": "^0.35.7",
-		"react-native-omni": "^1.11.1",
+		"react-native-omni": "^1.11.2",
 		"react-native-pager-view": "8.0.2",
 		"react-native-reanimated": "4.5.0",
 		"react-native-safe-area-context": "~5.7.0",

--- a/front/src/ui/player/language-preference.ts
+++ b/front/src/ui/player/language-preference.ts
@@ -41,7 +41,7 @@ export const useLanguagePreference = (
 
 	useEvent("audioTrackChange", (selected) => {
 		if (restoringAudio.current || !audios?.length) return;
-		const idx = player.audios.indexOf(selected);
+		const idx = player.audios.findIndex((x) => x.id === selected.id);
 		if (idx === -1 || !audios[idx]) return;
 		audioIdx.current = idx;
 		audioPref.current = audios[idx].language ?? audioPref.current;


### PR DESCRIPTION
Turns out old chromecast can't ABR into a different codec, it fails with the error 102. To fix this, we strip variants to only allow one codec.